### PR TITLE
Distribute rules to elements of repeated fields

### DIFF
--- a/java/src/main/java/io/spine/validation/java/JavaValidationRenderer.java
+++ b/java/src/main/java/io/spine/validation/java/JavaValidationRenderer.java
@@ -127,11 +127,11 @@ public final class JavaValidationRenderer extends JavaRenderer {
                               MessageType type) {
         File protoFile = findProtoFile(type.getFile());
         Path javaFile = javaFile(type, protoFile);
-        MessageValidation validation = validations.getOrDefault(type.getName(),
-                                                                MessageValidation
-                                                                        .newBuilder()
-                                                                        .setType(type)
-                                                                        .build());
+        MessageValidation defaultValidation = MessageValidation
+                .newBuilder()
+                .setType(type)
+                .build();
+        MessageValidation validation = validations.getOrDefault(type.getName(), defaultValidation);
         GeneratedCode code = generateValidationCode(validation);
         SourceAtPoint atClassScope = sources
                 .file(javaFile)

--- a/java/src/main/kotlin/io/spine/validation/java/CodeGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CodeGenerator.kt
@@ -49,7 +49,7 @@ internal abstract class CodeGenerator(
      * If the rule has a custom operator, the generator might not support it. Otherwise,
      * the generator must be able to generate code.
      */
-    open val canGenerate: Boolean = true
+    open fun canGenerate(): Boolean = true
 
     /**
      * Obtains the code checking the rule.
@@ -57,7 +57,7 @@ internal abstract class CodeGenerator(
      * Implementations report any found violations.
      */
     open fun code(): CodeBlock {
-        if (!canGenerate) {
+        if (!canGenerate()) {
             _debug().log("Standard Java renderer cannot generate rule: ${ctx.rule}")
             _debug().log("Skipping...")
             return CodeBlock.of("")
@@ -112,7 +112,7 @@ internal abstract class CodeGenerator(
 internal fun generatorFor(ctx: GenerationContext): CodeGenerator = with(ctx) {
     when (rule.kindCase) {
         SIMPLE -> generatorForSimple(this)
-        COMPOSITE -> CompositeRuleGenerator(ctx)
+        COMPOSITE -> CompositeRuleGenerator(this)
         else -> throw IllegalArgumentException("Empty rule.")
     }
 }

--- a/java/src/main/kotlin/io/spine/validation/java/CodeGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CodeGenerator.kt
@@ -49,7 +49,7 @@ internal abstract class CodeGenerator(
      * If the rule has a custom operator, the generator might not support it. Otherwise,
      * the generator must be able to generate code.
      */
-    open fun canGenerate(): Boolean = true
+    open val canGenerate: Boolean = true
 
     /**
      * Obtains the code checking the rule.
@@ -57,7 +57,7 @@ internal abstract class CodeGenerator(
      * Implementations report any found violations.
      */
     open fun code(): CodeBlock {
-        if (!canGenerate()) {
+        if (!canGenerate) {
             _debug().log("Standard Java renderer cannot generate rule: ${ctx.rule}")
             _debug().log("Skipping...")
             return CodeBlock.of("")

--- a/java/src/main/kotlin/io/spine/validation/java/CompositeRuleGenerators.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CompositeRuleGenerators.kt
@@ -54,19 +54,19 @@ private val BOOLEAN_OPS = mapOf(
  */
 internal class CompositeRuleGenerator(ctx: GenerationContext) : CodeGenerator(ctx) {
 
-    private fun left(ctx: GenerationContext) = generatorFor(ctx.left())
-    private fun right(ctx: GenerationContext) = generatorFor(ctx.right())
+    private val left = generatorFor(ctx.left())
+    private val right = generatorFor(ctx.right())
 
     private fun GenerationContext.left() = copy(rule = rule.composite.left)
     private fun GenerationContext.right() = copy(rule = rule.composite.right)
 
-    override fun canGenerate(): Boolean =
-        left(ctx).canGenerate() && right(ctx).canGenerate()
+    override val canGenerate: Boolean =
+        left.canGenerate && right.canGenerate
 
     override fun condition(): Expression = with(ctx) {
         val composite = rule.composite
-        val left = left(ctx).condition()
-        val right = right(ctx).condition()
+        val left = left.condition()
+        val right = right.condition()
         val binaryOp = BOOLEAN_OPS[composite.operator]!!
         return Literal(binaryOp(left.toCode(), right.toCode()))
     }
@@ -84,8 +84,8 @@ internal class CompositeRuleGenerator(ctx: GenerationContext) : CodeGenerator(ct
         }
         return ErrorMessage.forComposite(
             format,
-            left(ctx).error(),
-            right(ctx).error(),
+            left.error(),
+            right.error(),
             operation,
             fieldAccessor
         )
@@ -96,7 +96,7 @@ internal class CompositeRuleGenerator(ctx: GenerationContext) : CodeGenerator(ct
 
     override fun supportingMembers(): CodeBlock =
         CodeBlock.builder()
-            .add(left(ctx).supportingMembers())
-            .add(right(ctx).supportingMembers())
+            .add(left.supportingMembers())
+            .add(right.supportingMembers())
             .build()
 }

--- a/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
@@ -105,7 +105,7 @@ private class ValidateGenerator(ctx: GenerationContext) : SimpleRuleGenerator(ct
     }
 
     override fun condition(): Expression =
-        MethodCall(violationsVariable, "isPresent")
+        Literal("!" + MethodCall(violationsVariable, "isPresent"))
 
 
     override fun createViolation(): CodeBlock {

--- a/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
@@ -88,7 +88,7 @@ private class ValidateGenerator(ctx: GenerationContext) : SimpleRuleGenerator(ct
         val field = ctx.fieldFromSimpleRule!!
         val fieldType = field.type
         check(fieldType.hasMessage()) {
-            "(validate) only supports message types but field " +
+            "(validate) only supports `Message` types but field " +
                     "`${field.declaringType.qualifiedName()}.${field.name.value}` " +
                     "has type `$fieldType`."
         }

--- a/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
@@ -31,15 +31,19 @@ import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec
 import io.spine.option.PatternOption
 import io.spine.protobuf.AnyPacker.unpack
+import io.spine.protodata.Field.CardinalityCase.LIST
 import io.spine.protodata.codegen.java.ClassName
 import io.spine.protodata.codegen.java.Expression
 import io.spine.protodata.codegen.java.Literal
+import io.spine.protodata.codegen.java.MessageReference
 import io.spine.protodata.codegen.java.MethodCall
 import io.spine.protodata.isMap
+import io.spine.protodata.qualifiedName
 import io.spine.validate.ValidationError
 import io.spine.validation.DistinctCollection
 import io.spine.validation.RecursiveValidation
 import io.spine.validation.Regex
+import java.util.*
 import java.util.regex.Pattern
 import java.util.regex.Pattern.CASE_INSENSITIVE
 import java.util.regex.Pattern.DOTALL
@@ -58,6 +62,7 @@ private class DistinctGenerator(ctx: GenerationContext) : SimpleRuleGenerator(ct
 
     override fun condition(): Expression {
         val map = ctx.fieldFromSimpleRule!!.isMap()
+        val fieldValue = ctx.fieldOrElement!!
         val comparisonCollection = if (map) MethodCall(fieldValue, "values") else fieldValue
         return equalsOperator(
             MethodCall(fieldValue, "size"),
@@ -71,51 +76,60 @@ private class DistinctGenerator(ctx: GenerationContext) : SimpleRuleGenerator(ct
         return Literal(left.toCode() + " == " + right.toCode())
     }
 }
-
 /**
  * Generates code for the [RecursiveValidation] operator.
  */
-private class ValidateGenerator(
-    ctx: GenerationContext
-) : SimpleRuleGenerator(ctx) {
+private class ValidateGenerator(ctx: GenerationContext) : SimpleRuleGenerator(ctx) {
 
-    private val violationsVariable: Literal
-        get() = Literal("generated_validationError_${ctx.fieldFromSimpleRule!!.name.value}")
+    private val violationsVariable =
+        Literal("generated_validationError_${ctx.fieldFromSimpleRule!!.name.value}")
 
-    private val childViolations: MethodCall
-        get() = MethodCall(violationsVariable, "getAllConstraintViolation")
+    init {
+        val field = ctx.fieldFromSimpleRule!!
+        val fieldType = field.type
+        check(fieldType.hasMessage()) {
+            "(validate) only supports message types but field " +
+                    "`${field.declaringType.qualifiedName()}.${field.name.value}` " +
+                    "has type `$fieldType`."
+        }
+    }
+
+    override fun prologue(): CodeBlock {
+        val violations = MethodCall(ctx.fieldOrElement!!, "validate")
+        return CodeBlock
+            .builder()
+            .addStatement(
+                "\$T<\$T> \$L = \$L",
+                Optional::class.java, ValidationError::class.java, violationsVariable, violations
+            ).build()
+    }
 
     override fun condition(): Expression =
-        childViolations.chain("isEmpty")
+        MethodCall(violationsVariable, "isPresent")
 
-    override fun prologue(): CodeBlock =
-        CodeBlock.builder()
-            .addStatement(
-                "\$T \$L = ${MethodCall(fieldValue, "validate")}",
-                ValidationError::class.java, violationsVariable
-            ).build()
 
-    override fun createViolation(): CodeBlock =
-        error().createParentViolation(
-            field,
-            fieldValue,
-            ctx.violationsList,
-            childViolations
-        )
+    override fun createViolation(): CodeBlock {
+        val validationError = MethodCall(violationsVariable, "get")
+        val violations = MessageReference(validationError.toCode())
+            .field("constraint_violation", LIST)
+            .getter
+        return error().createParentViolation(ctx, violations)
+    }
 }
 
 /**
  * Generates code for the [Regex] operator.
  */
 private class PatternGenerator(
-    ctx: GenerationContext,
-    private val feature: Regex
+    private val feature: Regex,
+    ctx: GenerationContext
 ) : SimpleRuleGenerator(ctx) {
 
-    private val patternConstantName = "${ctx.fieldFromSimpleRule!!.name.value}_PATTERN"
+    private val fieldName = ctx.fieldFromSimpleRule!!.name
+    private val patternConstantName = "${fieldName.value}_PATTERN"
 
     override fun condition(): Expression {
-        val matcher = MethodCall(Literal(patternConstantName), "matcher", listOf(fieldValue))
+        val matcher = MethodCall(Literal(patternConstantName), "matcher", listOf(ctx.fieldOrElement!!))
         val matchingMethod = if (feature.modifier.partialMatch) {
             "find"
         } else {
@@ -143,7 +157,10 @@ private class PatternGenerator(
         } else {
             field.initializer("\$T.compile(\$S)", Pattern::class.java, feature.pattern)
         }
-        return CodeBlock.of(field.build().toString())
+        return super.supportingMembers()
+            .toBuilder()
+            .add(field.build().toString())
+            .build()
     }
 }
 
@@ -171,12 +188,11 @@ private fun PatternOption.Modifier.flagsMask(): Expression {
  * Use this generator when an unknown custom validation operator is encountered.
  */
 private class UnsupportedRuleGenerator(
-    ctx: GenerationContext,
-    private val ruleName: String
+    private val ruleName: String,
+    ctx: GenerationContext
 ) : CodeGenerator(ctx) {
 
-    override val canGenerate: Boolean
-        get() = false
+    override fun canGenerate(): Boolean = false
 
     override fun condition(): Nothing = unsupported()
 
@@ -198,7 +214,7 @@ internal fun generatorForCustom(ctx: GenerationContext): CodeGenerator {
     return when (feature) {
         is DistinctCollection -> DistinctGenerator(ctx)
         is RecursiveValidation -> ValidateGenerator(ctx)
-        is Regex -> PatternGenerator(ctx, feature)
-        else -> UnsupportedRuleGenerator(ctx, feature::class.simpleName!!)
+        is Regex -> PatternGenerator(feature, ctx)
+        else -> UnsupportedRuleGenerator(feature::class.simpleName!!, ctx)
     }
 }

--- a/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
@@ -192,7 +192,7 @@ private class UnsupportedRuleGenerator(
     ctx: GenerationContext
 ) : CodeGenerator(ctx) {
 
-    override fun canGenerate(): Boolean = false
+    override val canGenerate: Boolean = false
 
     override fun condition(): Nothing = unsupported()
 

--- a/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/CustomRuleGenerators.kt
@@ -58,9 +58,9 @@ private class DistinctGenerator(ctx: GenerationContext) : SimpleRuleGenerator(ct
 
     override fun condition(): Expression {
         val map = ctx.fieldFromSimpleRule!!.isMap()
-        val comparisonCollection = if (map) fieldValue.chain("values") else fieldValue
+        val comparisonCollection = if (map) MethodCall(fieldValue, "values") else fieldValue
         return equalsOperator(
-            fieldValue.chain("size"),
+            MethodCall(fieldValue, "size"),
             ClassName(ImmutableSet::class)
                 .call("copyOf", listOf(comparisonCollection))
                 .chain("size")
@@ -91,7 +91,7 @@ private class ValidateGenerator(
     override fun prologue(): CodeBlock =
         CodeBlock.builder()
             .addStatement(
-                "\$T \$L = ${fieldValue.chain("validate")}",
+                "\$T \$L = ${MethodCall(fieldValue, "validate")}",
                 ValidationError::class.java, violationsVariable
             ).build()
 

--- a/java/src/main/kotlin/io/spine/validation/java/DistributingGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/DistributingGenerator.kt
@@ -39,6 +39,15 @@ import io.spine.validate.ConstraintViolation
 import io.spine.validation.ErrorMessage
 import javax.lang.model.element.Modifier
 
+/**
+ * A code generator that distributes the associated simple validation rule to elements of
+ * a repeated field.
+ *
+ * A rule applied to a repeated fields, i.e. a list or a map, may be applied to the fields as
+ * a whole, or to individual elements of the field. In the first case, no extra modifications to
+ * code generation are required. In the second case, this generator creates code that iterated over
+ * the elements and applies the validation rule to them.
+ */
 internal class DistributingGenerator(
     ctx: GenerationContext,
     delegateCtor: (GenerationContext) -> CodeGenerator
@@ -100,6 +109,5 @@ internal class DistributingGenerator(
             .builder()
             .addStatement(methodCall.toCode())
             .build()
-
     }
 }

--- a/java/src/main/kotlin/io/spine/validation/java/DistributingGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/DistributingGenerator.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.validation.java
+
+import com.google.common.collect.ImmutableList
+import com.google.common.reflect.TypeToken
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.MethodSpec
+import io.spine.base.Identifier.newUuid
+import io.spine.protodata.codegen.java.Expression
+import io.spine.protodata.codegen.java.Literal
+import io.spine.protodata.codegen.java.MethodCall
+import io.spine.protodata.codegen.java.This
+import io.spine.validate.ConstraintViolation
+import io.spine.validation.ErrorMessage
+import javax.lang.model.element.Modifier
+
+internal class DistributingGenerator(
+    ctx: GenerationContext,
+    delegateCtor: (GenerationContext) -> CodeGenerator
+) : CodeGenerator(ctx) {
+
+    private val element = Literal("element")
+    private val elementContext = ctx.copy(elementReference = element)
+    private val field = ctx.fieldFromSimpleRule!!
+    private val delegate = delegateCtor(elementContext)
+    private val ruleId = "${field.name.value}_${newUuid().filter { it.isJavaIdentifierPart() }}"
+    private val methodName = "validate_$ruleId"
+    private val violationsName = "violations_of_$ruleId"
+    private val violationsType = object : TypeToken<ImmutableList<ConstraintViolation>>() {}.type
+
+    override fun supportingMembers(): CodeBlock {
+        val typeName = ctx.typeSystem.javaTypeName(field.type)
+        val body = CodeBlock
+            .builder()
+            .addStatement(
+                "\$T<\$T> \$N = \$T.builder()",
+                ImmutableList.Builder::class.java,
+                ConstraintViolation::class.java,
+                ctx.violationsList,
+                ImmutableList::class.java
+            ).beginControlFlow("for (\$L \$L : \$L)", typeName, element, ctx.fieldOrElement)
+            .add(delegate.code())
+            .endControlFlow()
+            .addStatement("return \$N.build()", elementContext.violationsList)
+            .build()
+        return CodeBlock.of(
+            MethodSpec
+                .methodBuilder(methodName)
+                .addModifiers(Modifier.PRIVATE)
+                .returns(violationsType)
+                .addCode(body)
+                .build()
+                .toString()
+        )
+    }
+
+    override fun prologue(): CodeBlock {
+        val methodCall = MethodCall(This, methodName)
+        return CodeBlock.builder()
+            .addStatement("\$T \$L = \$L", violationsType, violationsName, methodCall)
+            .build()
+    }
+
+    override fun condition(): Expression {
+        return MethodCall(Literal(violationsName), "isEmpty")
+    }
+
+    override fun error(): ErrorMessage =
+        delegate.error()
+
+    override fun createViolation(): CodeBlock {
+        val violations = Literal(ctx.violationsList)
+        val methodCall = MethodCall(violations, "addAll", listOf(Literal(violationsName)))
+        return CodeBlock
+            .builder()
+            .addStatement(methodCall.toCode())
+            .build()
+
+    }
+}

--- a/java/src/main/kotlin/io/spine/validation/java/GenerationContext.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/GenerationContext.kt
@@ -85,6 +85,12 @@ internal constructor(
      */
     private val querying: Querying,
 
+    /**
+     * A custom reference to an element of a collection field.
+     *
+     * If `null`, the associated field is not a collection or the associated rule does not need
+     * to be distributed to collection elements.
+     */
     private val elementReference: Expression? = null
 ) {
 
@@ -100,6 +106,12 @@ internal constructor(
             null
         }
 
+    /**
+     * If the associated field is a collection and the associated rule needs to be distributed,
+     * this is a reference to one element of the collection. If the field is not a collection or
+     * the rule does not need to be distributed, this is the reference to the field. If there is
+     * no associated field, this is `null`.
+     */
     val fieldOrElement: Expression?
         get() {
             if (elementReference != null) {
@@ -108,14 +120,26 @@ internal constructor(
             return fieldValue
         }
 
+    /**
+     * The reference to the associated field, or `null` if there is no such field.
+     */
     val fieldValue: Expression?
         get() {
             val protoField = fieldFromSimpleRule ?: return null
             return getterFor(protoField)
         }
 
+    /**
+     * `true` if the [fieldOrElement] contains a reference to an element of a collection,
+     * `false` otherwise.
+     */
     val isElement: Boolean = elementReference != null
 
+    /**
+     * Obtains a getter for a given field.
+     *
+     * The [field] should be a field of the message referenced in [msg].
+     */
     fun getterFor(field: Field): Expression =
         msg.field(field).getter
 

--- a/java/src/main/kotlin/io/spine/validation/java/SimpleRuleGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/SimpleRuleGenerator.kt
@@ -74,26 +74,22 @@ private val PRIMITIVE_COMPARISON_OPS = mapOf(
 /**
  * A generator for code which checks a simple one-field rule.
  */
-internal open class SimpleRuleGenerator(
-    ctx: GenerationContext
-) : CodeGenerator(ctx) {
+internal open class SimpleRuleGenerator(ctx: GenerationContext) : CodeGenerator(ctx) {
 
     protected val rule = ctx.rule.simple
-    private val ignoreIfNotSet: Boolean = rule.ignoredIfUnset
+    private val ignoreIfNotSet  = rule.ignoredIfUnset
     protected val field = ctx.fieldFromSimpleRule!!
-
-    protected val fieldValue: Expression by lazy { ctx.msg.field(field).getter }
-    private val otherValue: Expression by lazy { ctx.typeSystem.valueToJava(rule.otherValue) }
+    private val otherValue = ctx.typeSystem.valueToJava(rule.otherValue)
 
     override fun code(): CodeBlock {
         val check = super.code()
-        val defaultValue = UnsetValue.forField(field)
+        val defaultValue = UnsetValue.forField(ctx.fieldFromSimpleRule!!)
         if (!ignoreIfNotSet || !defaultValue.isPresent) {
             return check
         }
         val sign = selectSigns()[NOT_EQUAL]!!
         val defaultValueExpression = ctx.typeSystem.valueToJava(defaultValue.get())
-        val condition = sign(fieldValue.toCode(), defaultValueExpression.toCode())
+        val condition = sign(ctx.fieldOrElement!!.toCode(), defaultValueExpression.toCode())
         return CodeBlock
             .builder()
             .beginControlFlow("if ($condition)")
@@ -108,7 +104,8 @@ internal open class SimpleRuleGenerator(
         val compare = signs[rule.operator] ?: throw IllegalStateException(
             "Unsupported operation `${rule.operator}` for type `$type`."
         )
-        return Literal(compare(fieldValue.toCode(), otherValue.toCode()))
+        checkNotNull(ctx.fieldOrElement) { "There is no field value for rule: $rule" }
+        return Literal(compare(ctx.fieldOrElement!!.toCode(), otherValue.toCode()))
     }
 
     private fun selectSigns() = if (field.isJavaPrimitive()) {
@@ -118,7 +115,7 @@ internal open class SimpleRuleGenerator(
     }
 
     override fun error(): ErrorMessage {
-        val actualValue = ClassName(String::class).call("valueOf", listOf(fieldValue))
+        val actualValue = ClassName(String::class).call("valueOf", listOf(ctx.fieldOrElement!!))
         return ErrorMessage.forRule(
             rule.errorMessage,
             actualValue.toCode(),
@@ -127,10 +124,20 @@ internal open class SimpleRuleGenerator(
     }
 
     override fun createViolation(): CodeBlock =
-        error().createViolation(field, fieldValue, ctx.violationsList)
+        error().createViolation(ctx)
 }
 
 internal fun generatorForSimple(ctx: GenerationContext): CodeGenerator {
+    val distribute = ctx.rule.simple.distribute
+    val field = ctx.fieldFromSimpleRule!!
+    return if (distribute && field.isRepeated()) {
+        DistributingGenerator(ctx) { generatorForSingular(it) }
+    } else {
+        generatorForSingular(ctx)
+    }
+}
+
+private fun generatorForSingular(ctx: GenerationContext): CodeGenerator {
     val rule = ctx.rule.simple
     return when (rule.operatorKindCase) {
         OPERATOR -> SimpleRuleGenerator(ctx)
@@ -142,9 +149,6 @@ internal fun generatorForSimple(ctx: GenerationContext): CodeGenerator {
 }
 
 private fun Field.isJavaPrimitive(): Boolean {
-    if (isRepeated()) {
-        return false
-    }
     if (!type.hasPrimitive()) {
         return false
     }

--- a/java/src/main/kotlin/io/spine/validation/java/SimpleRuleGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/SimpleRuleGenerator.kt
@@ -33,7 +33,6 @@ import io.spine.protodata.PrimitiveType.TYPE_STRING
 import io.spine.protodata.codegen.java.ClassName
 import io.spine.protodata.codegen.java.Expression
 import io.spine.protodata.codegen.java.Literal
-import io.spine.protodata.codegen.java.MethodCall
 import io.spine.protodata.isRepeated
 import io.spine.validation.ComparisonOperator.EQUAL
 import io.spine.validation.ComparisonOperator.GREATER_OR_EQUAL
@@ -83,7 +82,7 @@ internal open class SimpleRuleGenerator(
     private val ignoreIfNotSet: Boolean = rule.ignoredIfUnset
     protected val field = ctx.fieldFromSimpleRule!!
 
-    protected val fieldValue: MethodCall by lazy { ctx.msg.field(field).getter }
+    protected val fieldValue: Expression by lazy { ctx.msg.field(field).getter }
     private val otherValue: Expression by lazy { ctx.typeSystem.valueToJava(rule.otherValue) }
 
     override fun code(): CodeBlock {
@@ -144,10 +143,10 @@ internal fun generatorForSimple(ctx: GenerationContext): CodeGenerator {
 
 private fun Field.isJavaPrimitive(): Boolean {
     if (isRepeated()) {
-        return false;
+        return false
     }
     if (!type.hasPrimitive()) {
-        return false;
+        return false
     }
     return when (type.primitive) {
         TYPE_STRING, TYPE_BYTES -> false

--- a/license-report.md
+++ b/license-report.md
@@ -647,7 +647,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 13:17:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:03:33 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1278,7 +1278,7 @@ This report was generated on **Wed Aug 18 13:17:48 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 13:17:56 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:03:41 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1846,7 +1846,7 @@ This report was generated on **Wed Aug 18 13:17:56 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 13:18:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:03:47 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2482,7 +2482,7 @@ This report was generated on **Wed Aug 18 13:18:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 13:18:04 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:03:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3143,7 +3143,7 @@ This report was generated on **Wed Aug 18 13:18:04 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 13:18:14 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:03:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3795,4 +3795,4 @@ This report was generated on **Wed Aug 18 13:18:14 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 13:18:15 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:03:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -647,7 +647,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 12 11:15:16 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 17 17:18:46 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1278,7 +1278,7 @@ This report was generated on **Thu Aug 12 11:15:16 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 12 11:15:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 17 17:18:54 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1846,7 +1846,7 @@ This report was generated on **Thu Aug 12 11:15:26 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 12 11:15:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 17 17:19:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2482,7 +2482,7 @@ This report was generated on **Thu Aug 12 11:15:32 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 12 11:15:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 17 17:19:01 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3143,7 +3143,7 @@ This report was generated on **Thu Aug 12 11:15:32 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 12 11:15:42 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 17 17:19:12 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3795,4 +3795,4 @@ This report was generated on **Thu Aug 12 11:15:42 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 12 11:15:43 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 17 17:19:13 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -647,7 +647,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 14:03:33 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:20:08 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1278,7 +1278,7 @@ This report was generated on **Wed Aug 18 14:03:33 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 14:03:41 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:20:16 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1846,7 +1846,7 @@ This report was generated on **Wed Aug 18 14:03:41 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 14:03:47 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:20:22 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2482,7 +2482,7 @@ This report was generated on **Wed Aug 18 14:03:47 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 14:03:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:20:23 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3143,7 +3143,7 @@ This report was generated on **Wed Aug 18 14:03:48 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 14:03:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:20:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3795,4 +3795,4 @@ This report was generated on **Wed Aug 18 14:03:58 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 14:03:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 14:20:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.validation:spine-java:2.0.0-SNAPSHOT.3`
+# Dependencies of `io.spine.validation:spine-java:2.0.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -112,9 +112,9 @@
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** javax.annotation **Name:** javax.annotation-api **Version:** 1.3.2
      * **Manifest Project URL:** [https://javaee.github.io/glassfish](https://javaee.github.io/glassfish)
@@ -391,9 +391,9 @@
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** jakarta.activation **Name:** jakarta.activation-api **Version:** 1.2.1
      * **Manifest Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
@@ -647,12 +647,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 17:18:46 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 13:17:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.validation:spine-model:2.0.0-SNAPSHOT.3`
+# Dependencies of `io.spine.validation:spine-model:2.0.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -760,7 +760,7 @@ This report was generated on **Tue Aug 17 17:18:46 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** javax.annotation **Name:** javax.annotation-api **Version:** 1.3.2
      * **Manifest Project URL:** [https://javaee.github.io/glassfish](https://javaee.github.io/glassfish)
@@ -1032,7 +1032,7 @@ This report was generated on **Tue Aug 17 17:18:46 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** jakarta.activation **Name:** jakarta.activation-api **Version:** 1.2.1
      * **Manifest Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
@@ -1278,12 +1278,12 @@ This report was generated on **Tue Aug 17 17:18:46 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 17:18:54 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 13:17:56 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.validation:spine-runtime:2.0.0-SNAPSHOT.3`
+# Dependencies of `io.spine.validation:spine-runtime:2.0.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -1594,13 +1594,13 @@ This report was generated on **Tue Aug 17 17:18:54 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** cli **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** cli **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** protoc **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** protoc **Version:** 0.0.32
 
 1. **Group:** jakarta.activation **Name:** jakarta.activation-api **Version:** 1.2.1
      * **Manifest Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
@@ -1846,12 +1846,12 @@ This report was generated on **Tue Aug 17 17:18:54 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 17:19:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 13:18:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.validation:spine-runtime-extensions:2.0.0-SNAPSHOT.3`
+# Dependencies of `io.spine.validation:spine-runtime-extensions:2.0.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -1963,9 +1963,9 @@ This report was generated on **Tue Aug 17 17:19:00 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** javax.annotation **Name:** javax.annotation-api **Version:** 1.3.2
      * **Manifest Project URL:** [https://javaee.github.io/glassfish](https://javaee.github.io/glassfish)
@@ -2234,9 +2234,9 @@ This report was generated on **Tue Aug 17 17:19:00 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** jakarta.activation **Name:** jakarta.activation-api **Version:** 1.2.1
      * **Manifest Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
@@ -2482,12 +2482,12 @@ This report was generated on **Tue Aug 17 17:19:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 17:19:01 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 13:18:04 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.validation:spine-test-consumer:2.0.0-SNAPSHOT.3`
+# Dependencies of `io.spine.validation:spine-test-consumer:2.0.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -2599,9 +2599,9 @@ This report was generated on **Tue Aug 17 17:19:01 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** javax.annotation **Name:** javax.annotation-api **Version:** 1.3.2
      * **Manifest Project URL:** [https://javaee.github.io/glassfish](https://javaee.github.io/glassfish)
@@ -2883,13 +2883,13 @@ This report was generated on **Tue Aug 17 17:19:01 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** cli **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** cli **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** protoc **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** protoc **Version:** 0.0.32
 
 1. **Group:** jakarta.activation **Name:** jakarta.activation-api **Version:** 1.2.1
      * **Manifest Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
@@ -3143,12 +3143,12 @@ This report was generated on **Tue Aug 17 17:19:01 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 17:19:12 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 13:18:14 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.validation:spine-test-extensions:2.0.0-SNAPSHOT.3`
+# Dependencies of `io.spine.validation:spine-test-extensions:2.0.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -3260,9 +3260,9 @@ This report was generated on **Tue Aug 17 17:19:12 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** javax.annotation **Name:** javax.annotation-api **Version:** 1.3.2
      * **Manifest Project URL:** [https://javaee.github.io/glassfish](https://javaee.github.io/glassfish)
@@ -3539,9 +3539,9 @@ This report was generated on **Tue Aug 17 17:19:12 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** codegen-java **Version:** 0.0.32
 
-1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.31
+1. **Group:** io.spine.protodata **Name:** compiler **Version:** 0.0.32
 
 1. **Group:** jakarta.activation **Name:** jakarta.activation-api **Version:** 1.2.1
      * **Manifest Project URL:** [https://www.eclipse.org](https://www.eclipse.org)
@@ -3795,4 +3795,4 @@ This report was generated on **Tue Aug 17 17:19:12 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 17:19:13 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 13:18:15 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model/src/main/java/io/spine/validation/DistinctPolicy.java
+++ b/model/src/main/java/io/spine/validation/DistinctPolicy.java
@@ -69,7 +69,7 @@ final class DistinctPolicy extends Policy<FieldOptionDiscovered> {
         checkCollection(event.getField(), event.getType(), event.getFile());
         FieldName field = event.getField();
         SimpleRule rule = SimpleRules.withCustom(
-                field, DistinctCollection.getDefaultInstance(), ERROR, ERROR
+                field, DistinctCollection.getDefaultInstance(), ERROR, ERROR, false
         );
         return EitherOf2.withA(SimpleRuleAdded
                                        .newBuilder()

--- a/model/src/main/java/io/spine/validation/PatternPolicy.java
+++ b/model/src/main/java/io/spine/validation/PatternPolicy.java
@@ -73,7 +73,8 @@ final class PatternPolicy extends Policy<FieldOptionDiscovered> {
                 event.getField(),
                 feature,
                 "String should match regex.",
-                error
+                error,
+                true
         );
         return EitherOf2.withA(
                 SimpleRuleAdded.newBuilder()

--- a/model/src/main/java/io/spine/validation/RequiredRulePolicy.java
+++ b/model/src/main/java/io/spine/validation/RequiredRulePolicy.java
@@ -75,6 +75,7 @@ final class RequiredRulePolicy extends Policy<FieldOptionDiscovered> {
                 .setField(field.getName())
                 .setOperator(NOT_EQUAL)
                 .setOtherValue(unsetValue)
+                .setDistribute(false)
                 .vBuild();
         return SimpleRuleAdded
                 .newBuilder()

--- a/model/src/main/java/io/spine/validation/SimpleRules.java
+++ b/model/src/main/java/io/spine/validation/SimpleRules.java
@@ -61,7 +61,8 @@ public final class SimpleRules {
             FieldName field,
             Message customFeature,
             String description,
-            String errorMessage
+            String errorMessage,
+            boolean distribute
     ) {
         checkNotNull(field);
         checkNotNull(customFeature);
@@ -80,6 +81,7 @@ public final class SimpleRules {
                 .setErrorMessage(errorMessage)
                 .setIgnoredIfUnset(true)
                 .setOtherValue(other)
+                .setDistribute(distribute)
                 .build();
         return rule;
     }

--- a/model/src/main/java/io/spine/validation/ValidatePolicy.java
+++ b/model/src/main/java/io/spine/validation/ValidatePolicy.java
@@ -74,7 +74,8 @@ final class ValidatePolicy extends Policy<FieldOptionDiscovered> {
                 RecursiveValidation.getDefaultInstance(),
                 "Message field is validated by its validation rules. " +
                         "If the field is invalid, the container message is invalid as well.",
-                "Message must be valid.");
+                "Message must be valid.",
+                true);
         return EitherOf2.withA(SimpleRuleAdded
                                        .newBuilder()
                                        .setType(event.getType())

--- a/model/src/main/java/io/spine/validation/ValidatePolicy.java
+++ b/model/src/main/java/io/spine/validation/ValidatePolicy.java
@@ -42,7 +42,6 @@ import io.spine.validation.event.SimpleRuleAdded;
 
 import static io.spine.option.OptionsProto.validate;
 import static io.spine.protobuf.AnyPacker.unpack;
-import static io.spine.protodata.Ast.isRepeated;
 import static io.spine.protodata.Ast.qualifiedName;
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static io.spine.validation.Options.is;
@@ -85,7 +84,7 @@ final class ValidatePolicy extends Policy<FieldOptionDiscovered> {
 
     private void checkMessage(FieldName fieldName, TypeName typeName, FilePath file) {
         Field field = findField(fieldName, typeName, file, this);
-        if (!isRepeated(field)) {
+        if (!field.getType().hasMessage()) {
             throw newIllegalStateException(
                     "Field `%s.%s` is not a message field and " +
                             "therefore should not be marked with `validate`.",

--- a/model/src/main/kotlin/io/spine/validation/NumberRules.kt
+++ b/model/src/main/kotlin/io/spine/validation/NumberRules.kt
@@ -43,7 +43,6 @@ import io.spine.validation.ComparisonOperator.LESS_THAN
 import io.spine.validation.LogicalOperator.AND
 import io.spine.validation.Value.KindCase.DOUBLE_VALUE
 import io.spine.validation.Value.KindCase.INT_VALUE
-import java.lang.IllegalStateException
 
 /**
  * A factory of validation rules for number fields.
@@ -81,6 +80,7 @@ private constructor(
             .setOperator(if (inclusive) inclusiveOperator else exclusiveOperator)
             .setOtherValue(threshold)
             .setErrorMessage(compileErrorMessage(adjective, inclusive))
+            .setDistribute(true)
             .build()
 
     private fun compileErrorMessage(adjective: String, inclusive: Boolean): String {

--- a/model/src/main/proto/spine/validation/rule.proto
+++ b/model/src/main/proto/spine/validation/rule.proto
@@ -81,6 +81,16 @@ message SimpleRule {
     // This does not apply to simple rules which are parts of a `CompositeRule`.
     //
     bool ignored_if_unset = 6;
+
+    // If the associated field is a list or a map, this value shows whether the rule is applied
+    // to the collection as a whole or to each element individually.
+    //
+    // If `true`, the rule is applied to each element (each value, in case of a map). Otherwise,
+    // to the collection as a whole.
+    //
+    // If the associated field is not a collection, the value is ignored.
+    //
+    bool distribute = 7;
 }
 
 // A predefined comparison operator.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.3</version>
+<version>2.0.0-SNAPSHOT.4</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -58,13 +58,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>codegen-java</artifactId>
-    <version>0.0.31</version>
+    <version>0.0.32</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>compiler</artifactId>
-    <version>0.0.31</version>
+    <version>0.0.32</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -146,12 +146,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>cli</artifactId>
-    <version>0.0.31</version>
+    <version>0.0.32</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protoc</artifactId>
-    <version>0.0.31</version>
+    <version>0.0.32</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/test/consumer/src/main/proto/test/blizzard.proto
+++ b/test/consumer/src/main/proto/test/blizzard.proto
@@ -18,3 +18,18 @@ message Blizzard {
 
     repeated Snowflake snowflake = 1 [(distinct) = true];
 }
+
+message RainDrop {
+
+    int32 mass_in_grams = 1 [(min) = { value: "1", exclusive: false}];
+}
+
+message Rain {
+
+    repeated RainDrop rain_drop = 1 [(required) = true, (validate) = true];
+}
+
+message MeteoStatistics {
+
+    RainDrop average_drop = 1 [(validate) = true];
+}

--- a/test/consumer/src/main/proto/test/bookshelf.proto
+++ b/test/consumer/src/main/proto/test/bookshelf.proto
@@ -21,9 +21,19 @@ message Book {
             unicode: true
         }
     }];
+
+    repeated ChapterIndex index = 3 [(validate) = true];
+
+    repeated int32 previously_published_in_year = 4 [(min).value = "1"];
 }
 
 message Author {
 
     string name = 1;
+}
+
+message ChapterIndex {
+
+    string chapter_name = 1;
+    int32 page_number = 2;
 }

--- a/test/consumer/src/test/java/io/spine/validation/test/ValidationTest.java
+++ b/test/consumer/src/test/java/io/spine/validation/test/ValidationTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.validation.test;
 
-import com.google.common.truth.Truth;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
 import io.spine.validate.ConstraintViolation;
@@ -42,7 +41,6 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.function.Supplier;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -148,13 +146,9 @@ class ValidationTest {
         @Test
         @DisplayName(ALLOW_VALID)
         void pass() {
-            Player player = Player.newBuilder()
-                    .setShirtName("Regina Falangee")
-                    .build();
-            Truth.assertThat(player)
-                 .isNotNull();
-            assertThat(player.validate())
-                    .isEmpty();
+            Message.Builder player = Player.newBuilder()
+                    .setShirtName("Regina Falangee");
+            noException(player::build);
         }
 
         @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,7 +27,7 @@
 project.extra.apply {
     this["spineBaseVersion"] = "2.0.0-SNAPSHOT.40"
     this["spineServerVersion"] = "2.0.0-SNAPSHOT.41"
-    this["protoDataVersion"] = "0.0.31"
-    this["validationVersion"] = "2.0.0-SNAPSHOT.3"
+    this["protoDataVersion"] = "0.0.32"
+    this["validationVersion"] = "2.0.0-SNAPSHOT.4"
 }
 


### PR DESCRIPTION
In this PR we enable list and map Protobuf fields to have the same validation rules as do singular fields.
This includes distinguishing between rules that are applied to the whole collection and rules that are applied to individual elements.