### PR TITLE
Extract `fatJar` publishing

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -231,6 +231,7 @@
     <inspection_tool class="EnumerationCanBeIteration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EqualsAndHashcode" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EqualsCalledOnEnumConstant" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="EqualsHashCodeCalledOnUrl" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EqualsUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ErrorRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ExceptionFromCatchWhichDoesntWrap" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,42 +22,19 @@
     <option name="myDefaultNotNull" value="org.checkerframework.checker.nullness.qual.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="15">
-          <item index="0" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
-          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
-          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
-          <item index="3" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
-          <item index="4" class="java.lang.String" itemvalue="org.jspecify.nullness.Nullable" />
-          <item index="5" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
-          <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
-          <item index="7" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
-          <item index="8" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
-          <item index="9" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
-          <item index="10" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
-          <item index="11" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
-          <item index="12" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
-          <item index="13" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
-          <item index="14" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
+        <list size="3">
+          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="14">
-          <item index="0" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
-          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
-          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
-          <item index="3" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
-          <item index="4" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
-          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
-          <item index="6" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
-          <item index="7" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
-          <item index="8" class="java.lang.String" itemvalue="org.jspecify.nullness.NonNull" />
-          <item index="9" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
-          <item index="10" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
-          <item index="11" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
-          <item index="12" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
-          <item index="13" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+        <list size="3">
+          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
         </list>
       </value>
     </option>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,10 @@ spinePublishing {
         "java-runtime",
         "java-runtime-bundle",
     )
+    modulesWithCustomPublishing = setOf(
+        "java-bundle",
+        "java-runtime-bundle"
+    )
     destinations = with(PublishingRepos) {
         setOf(
             cloudRepo,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,12 +73,13 @@ plugins {
 
 spinePublishing {
     modules = setOf(
+        "model",
         ":proto:configuration",
         ":proto:context",
         "java",
         "java-bundle",
         "java-runtime",
-        "model"
+        "java-runtime-bundle",
     )
     destinations = with(PublishingRepos) {
         setOf(
@@ -116,7 +117,6 @@ subprojects {
     applyPlugins()
     addDependencies()
     forceConfigurations()
-
     applyGeneratedDirectories("$projectDir/generated")
 
     val javaVersion = JavaVersion.VERSION_11

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -156,4 +156,7 @@ dependencies {
 
     // https://github.com/srikanth-lingala/zip4j
     implementation("net.lingala.zip4j:zip4j:2.10.0")
+
+    // https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow
+    implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -109,6 +109,13 @@ val dokkaVersion = "1.7.20"
  */
 val detektVersion = "1.21.0"
 
+/**
+ * The version of Gradle Shadow plugin.
+ *
+ * @see <a href="https://github.com/johnrengelman/shadow">Gradle Shadow</a>
+ */
+val gradleShadowVersion = "7.1.2"
+
 configurations.all {
     resolutionStrategy {
         force(
@@ -137,7 +144,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
+    implementation(
+        "com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
         exclude(group = "com.google.guava")
     }
     implementation("com.google.guava:guava:$guavaVersion")
@@ -153,10 +161,8 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}")
     implementation("org.jetbrains.dokka:dokka-base:${dokkaVersion}")
+    implementation("gradle.plugin.com.github.johnrengelman:shadow:$gradleShadowVersion")
 
     // https://github.com/srikanth-lingala/zip4j
     implementation("net.lingala.zip4j:zip4j:2.10.0")
-
-    // https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow
-    implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,6 +24,8 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+@file:Suppress("UnusedReceiverParameter", "unused")
+
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Protobuf

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,8 +24,6 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-@file:Suppress("unused", "UnusedReceiverParameter")
-
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Protobuf

--- a/buildSrc/src/main/kotlin/fat-jar.gradle.kts
+++ b/buildSrc/src/main/kotlin/fat-jar.gradle.kts
@@ -25,14 +25,6 @@
  */
 
 import io.spine.internal.gradle.publish.SpinePublishing
-import org.gradle.api.Task
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.getting
-import org.gradle.kotlin.dsl.java
-import org.gradle.kotlin.dsl.`maven-publish`
-import org.gradle.kotlin.dsl.project
-import org.gradle.kotlin.dsl.the
 
 plugins {
     `maven-publish`
@@ -44,10 +36,10 @@ plugins {
  * Creates a custom publication called `fatJar`, taking the output of `tasks.shadowJar`
  * as the sole publication artifact.
  *
- * This publication works in combination with exclusion of standard publishing for this
+ * This kind of publishing works in combination with exclusion of standard publishing for this
  * module specified in the root project under [SpinePublishing.modulesWithCustomPublishing].
  */
-project.publishing {
+publishing {
     publications {
         // The publishing settings from the root project.
         val spinePublishing = rootProject.the<SpinePublishing>()

--- a/buildSrc/src/main/kotlin/fat-jar.gradle.kts
+++ b/buildSrc/src/main/kotlin/fat-jar.gradle.kts
@@ -25,15 +25,19 @@
  */
 
 import io.spine.internal.gradle.publish.SpinePublishing
+import org.gradle.api.Task
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.getValue
+import org.gradle.kotlin.dsl.getting
+import org.gradle.kotlin.dsl.java
+import org.gradle.kotlin.dsl.`maven-publish`
+import org.gradle.kotlin.dsl.project
+import org.gradle.kotlin.dsl.the
 
 plugins {
     `maven-publish`
     id("com.github.johnrengelman.shadow")
     java
-}
-
-dependencies {
-    api(project(":java-runtime"))
 }
 
 /**
@@ -43,7 +47,7 @@ dependencies {
  * This publication works in combination with exclusion of standard publishing for this
  * module specified in the root project under [SpinePublishing.modulesWithCustomPublishing].
  */
-publishing {
+project.publishing {
     publications {
         // The publishing settings from the root project.
         val spinePublishing = rootProject.the<SpinePublishing>()
@@ -62,6 +66,16 @@ tasks.publish {
 
 tasks.shadowJar {
     exclude(
+        /**
+         * Excluding this type to avoid it being located in the fat JAR.
+         *
+         * Locating this type in its own `io:spine:protodata` artifact is crucial
+         * for obtaining proper version values from the manifest file.
+         * This file is only present in `io:spine:protodata` artifact.
+         */
+        "io/spine/protodata/gradle/plugin/Plugin.class",
+        "META-INF/gradle-plugins/io.spine.protodata.properties",
+
         /**
          * Exclude Gradle types to reduce the size of the resulting JAR.
          *

--- a/buildSrc/src/main/kotlin/fat-jar.gradle.kts
+++ b/buildSrc/src/main/kotlin/fat-jar.gradle.kts
@@ -27,9 +27,9 @@
 import io.spine.internal.gradle.publish.SpinePublishing
 
 plugins {
-    `maven-publish`
-    id("com.github.johnrengelman.shadow")
     java
+    `maven-publish`
+    com.github.johnrengelman.shadow
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -35,105 +35,33 @@ import java.util.*
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.kotlin.dsl.ScriptHandlerScope
 
 /**
- * A Maven repository.
+ * Applies [standard][doApplyStandard] repositories to this [ScriptHandlerScope]
+ * optionally adding [gitHub] repositories for Spine-only components, if
+ * names of such repositories are given.
+ *
+ * @param buildscript
+ *         a [ScriptHandlerScope] to work with. Pass `this` under `buildscript { }`.
+ * @param rootProject
+ *         a root project where the `buildscript` is declared.
+ * @param gitHubRepo
+ *         a list of short repository names, or empty list if only
+ *         [standard repositories][doApplyStandard] are required.
  */
-data class Repository(
-    val releases: String,
-    val snapshots: String,
-    private val credentialsFile: String? = null,
-    private val credentialValues: ((Project) -> Credentials?)? = null,
-    val name: String = "Maven repository `$releases`"
+@Suppress("unused")
+fun applyWithStandard(
+    buildscript: ScriptHandlerScope,
+    rootProject: Project,
+    vararg gitHubRepo: String
 ) {
-
-    /**
-     * Obtains the publishing password credentials to this repository.
-     *
-     * If the credentials are represented by a `.properties` file, reads the file and parses
-     * the credentials. The file must have properties `user.name` and `user.password`, which store
-     * the username and the password for the Maven repository auth.
-     */
-    fun credentials(project: Project): Credentials? {
-        if (credentialValues != null) {
-            return credentialValues.invoke(project)
-        }
-        credentialsFile!!
-        val log = project.logger
-        log.info("Using credentials from `$credentialsFile`.")
-        val file = project.rootProject.file(credentialsFile)
-        if (!file.exists()) {
-            return null
-        }
-        val creds = file.readCredentials()
-        log.info("Publishing build as `${creds.username}`.")
-        return creds
+    val repositories = buildscript.repositories
+    gitHubRepo.iterator().forEachRemaining { repo ->
+        repositories.applyGitHubPackages(repo, rootProject)
     }
-
-    private fun File.readCredentials(): Credentials {
-        val properties = Properties()
-        properties.load(inputStream())
-        val username = properties.getProperty("user.name")
-        val password = properties.getProperty("user.password")
-        return Credentials(username, password)
-    }
-
-    override fun toString(): String {
-        return name
-    }
+    repositories.applyStandard()
 }
-
-/**
- * Password credentials for a Maven repository.
- */
-data class Credentials(
-    val username: String?,
-    val password: String?
-)
-
-/**
- * Defines names of additional repositories commonly used in the framework projects.
- *
- * @see [applyStandard]
- */
-@Suppress("unused")
-object Repos {
-    @Deprecated(
-        message = "Please use another repository.",
-        replaceWith = ReplaceWith("artifactRegistry"),
-        level = DeprecationLevel.ERROR
-    )
-    val oldSpine = PublishingRepos.mavenTeamDev.releases
-
-    @Deprecated(
-        message = "Please use another repository.",
-        replaceWith = ReplaceWith("artifactRegistrySnapshots"),
-        level = DeprecationLevel.ERROR
-    )
-    val oldSpineSnapshots = PublishingRepos.mavenTeamDev.snapshots
-
-    val spine = CloudRepo.published.releases
-    val spineSnapshots = CloudRepo.published.snapshots
-
-    val artifactRegistry = PublishingRepos.cloudArtifactRegistry.releases
-    val artifactRegistrySnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
-
-    @Deprecated(
-        message = "Sonatype release repository redirects to the Maven Central",
-        replaceWith = ReplaceWith("sonatypeSnapshots"),
-        level = DeprecationLevel.ERROR
-    )
-    const val sonatypeReleases = "https://oss.sonatype.org/content/repositories/snapshots"
-    const val sonatypeSnapshots = "https://oss.sonatype.org/content/repositories/snapshots"
-}
-
-/**
- * Registers the standard set of Maven repositories.
- *
- * To be used in `buildscript` clauses when a fully-qualified call must be made.
- */
-@Suppress("unused")
-fun doApplyStandard(repositories: RepositoryHandler) = repositories.applyStandard()
 
 /**
  * Registers the selected GitHub Packages repos as Maven repositories.
@@ -154,6 +82,14 @@ fun doApplyGitHubPackages(
     shortRepositoryName: String,
     project: Project
 ) = repositories.applyGitHubPackages(shortRepositoryName, project)
+
+/**
+ * Registers the standard set of Maven repositories.
+ *
+ * To be used in `buildscript` clauses when a fully-qualified call must be made.
+ */
+@Suppress("unused")
+fun doApplyStandard(repositories: RepositoryHandler) = repositories.applyStandard()
 
 /**
  * Applies the repository hosted at GitHub Packages, to which Spine artifacts were published.
@@ -195,13 +131,31 @@ fun RepositoryHandler.applyGitHubPackages(project: Project, vararg shortReposito
 }
 
 /**
+ * Applies [standard][applyStandard] repositories to this [RepositoryHandler]
+ * optionally adding [applyGitHubPackages] repositories for Spine-only components, if
+ * names of such repositories are given.
+ *
+ * @param project
+ *         a project to which we add dependencies
+ * @param gitHubRepo
+ *         a list of short repository names, or empty list if only
+ *         [standard repositories][applyStandard] are required.
+ */
+@Suppress("unused")
+fun RepositoryHandler.applyStandardWithGitHub(project: Project, vararg gitHubRepo: String) {
+    gitHubRepo.iterator().forEachRemaining { repo ->
+        applyGitHubPackages(repo, project)
+    }
+    applyStandard()
+}
+
+/**
  * Applies repositories commonly used by Spine Event Engine projects.
  *
  * Does not include the repositories hosted at GitHub Packages.
  *
  * @see applyGitHubPackages
  */
-@Suppress("unused")
 fun RepositoryHandler.applyStandard() {
 
     val spineRepos = listOf(
@@ -227,6 +181,86 @@ fun RepositoryHandler.applyStandard() {
     mavenCentral()
     gradlePluginPortal()
     mavenLocal().includeSpineOnly()
+}
+
+/**
+ * A Maven repository.
+ */
+data class Repository(
+    val releases: String,
+    val snapshots: String,
+    private val credentialsFile: String? = null,
+    private val credentialValues: ((Project) -> Credentials?)? = null,
+    val name: String = "Maven repository `$releases`"
+) {
+
+    /**
+     * Obtains the publishing password credentials to this repository.
+     *
+     * If the credentials are represented by a `.properties` file, reads the file and parses
+     * the credentials. The file must have properties `user.name` and `user.password`, which store
+     * the username and the password for the Maven repository auth.
+     */
+    fun credentials(project: Project): Credentials? = when {
+        credentialValues != null -> credentialValues.invoke(project)
+        credentialsFile != null -> credsFromFile(credentialsFile, project)
+        else -> throw IllegalArgumentException(
+            "Credentials file or a supplier function should be passed."
+        )
+    }
+
+    private fun credsFromFile(fileName: String, project: Project): Credentials? {
+        val file = project.rootProject.file(fileName)
+        if (file.exists().not()) {
+            return null
+        }
+
+        val log = project.logger
+        log.info("Using credentials from `$fileName`.")
+        val creds = file.parseCredentials()
+        log.info("Publishing build as `${creds.username}`.")
+        return creds
+    }
+
+    private fun File.parseCredentials(): Credentials {
+        val properties = Properties().apply { load(inputStream()) }
+        val username = properties.getProperty("user.name")
+        val password = properties.getProperty("user.password")
+        return Credentials(username, password)
+    }
+
+    override fun toString(): String {
+        return name
+    }
+}
+
+/**
+ * Password credentials for a Maven repository.
+ */
+data class Credentials(
+    val username: String?,
+    val password: String?
+)
+
+/**
+ * Defines names of additional repositories commonly used in the Spine SDK projects.
+ *
+ * @see [applyStandard]
+ */
+private object Repos {
+    val spine = CloudRepo.published.releases
+    val spineSnapshots = CloudRepo.published.snapshots
+    val artifactRegistry = PublishingRepos.cloudArtifactRegistry.releases
+    val artifactRegistrySnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
+
+    @Suppress("unused")
+    @Deprecated(
+        message = "Sonatype release repository redirects to the Maven Central",
+        replaceWith = ReplaceWith("sonatypeSnapshots"),
+        level = DeprecationLevel.ERROR
+    )
+    const val sonatypeReleases = "https://oss.sonatype.org/content/repositories/snapshots"
+    const val sonatypeSnapshots = "https://oss.sonatype.org/content/repositories/snapshots"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -55,7 +55,6 @@ open class RunGradle : DefaultTask() {
         private const val BUILD_TIMEOUT_MINUTES: Long = 10
     }
 
-
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -47,6 +47,15 @@ import org.gradle.internal.os.OperatingSystem
 @Suppress("unused")
 open class RunGradle : DefaultTask() {
 
+    companion object {
+
+        /**
+         * Default Gradle build timeout.
+         */
+        private const val BUILD_TIMEOUT_MINUTES: Long = 10
+    }
+
+
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */
@@ -62,7 +71,7 @@ open class RunGradle : DefaultTask() {
      * For how many minutes to wait for the Gradle build to complete.
      */
     @Internal
-    var maxDurationMins: Long = 10
+    var maxDurationMins: Long = BUILD_TIMEOUT_MINUTES
 
     /**
      * Names of Gradle properties to copy into the launched build.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -97,7 +97,7 @@ abstract class WriteVersions : DefaultTask() {
      * `versions-spine-tools.properties`.
      */
     @TaskAction
-    private fun writeFile() {
+    fun writeFile() {
         versions.finalizeValue()
         versionsFileLocation.finalizeValue()
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/fs/LazyTempPath.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/fs/LazyTempPath.kt
@@ -42,17 +42,10 @@ import java.nio.file.WatchService
  * After the first usage, the instances of this type delegate all calls to the internally
  * created instance of [Path] created with [createTempDirectory].
  */
+@Suppress("TooManyFunctions")
 class LazyTempPath(private val prefix: String) : Path {
 
-    private lateinit var tempPath: Path
-
-    private val delegate: Path
-        get() {
-            if (!::tempPath.isInitialized) {
-                tempPath = createTempDirectory(prefix)
-            }
-            return tempPath
-        }
+    private val delegate: Path by lazy { createTempDirectory(prefix) }
 
     override fun compareTo(other: Path): Int = delegate.compareTo(other)
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/AuthorEmail.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/AuthorEmail.kt
@@ -45,10 +45,8 @@ class AuthorEmail(val value: String) {
          */
         fun fromVar() : AuthorEmail {
             val envValue = System.getenv(environmentVariable)
-            if (envValue.isNullOrEmpty()) {
-                throw IllegalStateException(
-                    "Unable to obtain an author from `${environmentVariable}`."
-                )
+            check(envValue != null && envValue.isNotBlank()) {
+                "Unable to obtain an author from `${environmentVariable}`."
             }
             return AuthorEmail(envValue)
         }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
@@ -177,7 +177,7 @@ class UpdateGitHubPages : Plugin<Project> {
         val inputs = composeJavadocInputs(allowInternalJavadoc)
 
         register(copyJavadoc, Copy::class.java) {
-            from(*inputs.toTypedArray())
+            inputs.forEach { from(it) }
             into(javadocOutputFolder)
         }
     }
@@ -197,7 +197,7 @@ class UpdateGitHubPages : Plugin<Project> {
         val inputs = composeDokkaInputs()
 
         register(copyDokka, Copy::class.java) {
-            from(*inputs.toTypedArray())
+            inputs.forEach { from(it) }
             into(dokkaOutputFolder)
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
@@ -82,6 +82,7 @@ private object ErrorProneConfig {
 
             "-Xep:CheckReturnValue:OFF",
             "-Xep:FloggerSplitLogStatement:OFF",
+            "-Xep:FloggerLogString:OFF"
         )
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
@@ -56,7 +56,7 @@ open class CheckVersionIncrement : DefaultTask() {
     val version: String = project.version as String
 
     @TaskAction
-    private fun fetchAndCheck() {
+    fun fetchAndCheck() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
         checkInRepo(repository.snapshots, artifact)
 
@@ -119,7 +119,7 @@ private data class MavenMetadata(var versioning: Versioning = Versioning()) {
             return try {
                 val metadata = mapper.readValue(url, MavenMetadata::class.java)
                 metadata
-            } catch (e: FileNotFoundException) {
+            } catch (ignored: FileNotFoundException) {
                 null
             }
         }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/MavenJavaPublication.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/MavenJavaPublication.kt
@@ -167,3 +167,14 @@ internal class MavenJavaPublication(
         }
     }
 }
+
+internal class CustomPublications(artifactId: String, destinations: Set<Repository>) :
+    PublicationHandler(artifactId, destinations) {
+
+    override fun handlePublications(project: Project) {
+        project.publications.forEach {
+            val publication = it as MavenPublication
+            publication.specifyMavenCoordinates(project)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -179,7 +179,7 @@ private fun MavenPublication.specifyArtifacts(project: Project, jars: Set<TaskPr
  * A handler for custom publications, which is declared under the [publications] section
  * of a module.
  *
- * Such publications should be treated is treated differently than [MavenJavaPublication],
+ * Such publications should be treated differently than [MavenJavaPublication],
  * which is created for a module. Instead, since they are already declared, this class
  * only [assigns maven coordinates][assignMavenCoordinates].
  *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -180,8 +180,8 @@ private fun MavenPublication.specifyArtifacts(project: Project, jars: Set<TaskPr
  * of a module.
  *
  * Such publications should be treated differently than [MavenJavaPublication],
- * which is created for a module. Instead, since they are already declared, this class
- * only [assigns maven coordinates][assignMavenCoordinates].
+ * which <em>creates</em> for a module. Instead, since the publications are already declared,
+ * this class only [assigns maven coordinates][assignMavenCoordinates].
  *
  * A module which declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -189,7 +189,7 @@ private fun MavenPublication.specifyArtifacts(project: Project, jars: Set<TaskPr
  * If a module with [publications] declared locally is not specified as one with custom publishing,
  * it may cause a name clash between an artifact produced by the [standard][MavenPublication]
  * publication, and custom ones. In order to have both standard and custom publications,
- * please specify custom artifact IDs or classifiers for custom ones.
+ * please specify custom artifact IDs or classifiers for each custom publication.
  */
 internal class CustomPublications(artifactId: String, destinations: Set<Repository>) :
     PublicationHandler(artifactId, destinations) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -35,11 +35,19 @@ import org.gradle.kotlin.dsl.apply
 /**
  * Information, required to set up publishing of a project using `maven-publish` plugin.
  *
- * @param artifactId a name that a project is known by.
- * @param destinations set of repositories, to which the resulting artifacts will be sent.
- * @param includeProtoJar tells whether [protoJar] artifact should be published.
- * @param includeTestJar tells whether [testJar] artifact should be published.
- * @param includeDokkaJar tells whether [dokkaJar] artifact should be published.
+ * @param artifactId
+ *         a name that a project is known by.
+ * @param destinations
+ *         set of repositories, to which the resulting artifacts will be sent.
+ * @param includeProtoJar
+ *         tells whether [protoJar] artifact should be published.
+ * @param includeTestJar
+ *         tells whether [testJar] artifact should be published.
+ * @param includeDokkaJar
+ *         tells whether [dokkaJar] artifact should be published.
+ * @param customPublishing
+ *         tells whether subproject declares own publishing and standard one
+ *         should not be applied.
  */
 internal class PublishingConfig(
     val artifactId: String,
@@ -63,11 +71,11 @@ internal class PublishingConfig(
  */
 internal fun PublishingConfig.apply(project: Project) = with(project) {
     apply(plugin = "maven-publish")
-    createPublication(project)
+    handlePublication(project)
     configurePublishTask(destinations)
 }
 
-private fun PublishingConfig.createPublication(project: Project) {
+private fun PublishingConfig.handlePublication(project: Project) {
     if (customPublishing) {
         handleCustomPublications(project)
     } else {
@@ -75,10 +83,13 @@ private fun PublishingConfig.createPublication(project: Project) {
     }
 }
 
-private fun handleCustomPublications(project: Project) {
-    project.logger.info(
-        "The project `${project.name}` is set to provide custom publishing."
+private fun PublishingConfig.handleCustomPublications(project: Project) {
+    project.logger.info("The project `${project.name}` is set to provide custom publishing.")
+    val publications = CustomPublications(
+        artifactId = artifactId,
+        destinations = destinations
     )
+    publications.registerIn(project)
 }
 
 private fun PublishingConfig.createStandardPublication(project: Project) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -46,7 +46,8 @@ internal class PublishingConfig(
     val destinations: Set<Repository>,
     val includeProtoJar: Boolean = true,
     val includeTestJar: Boolean = false,
-    val includeDokkaJar: Boolean = false
+    val includeDokkaJar: Boolean = false,
+    val customPublishing: Boolean = false
 )
 
 /**
@@ -67,6 +68,20 @@ internal fun PublishingConfig.apply(project: Project) = with(project) {
 }
 
 private fun PublishingConfig.createPublication(project: Project) {
+    if (customPublishing) {
+        handleCustomPublications(project)
+    } else {
+        createStandardPublication(project)
+    }
+}
+
+private fun handleCustomPublications(project: Project) {
+    project.logger.info(
+        "The project `${project.name}` is set to provide custom publishing."
+    )
+}
+
+private fun PublishingConfig.createStandardPublication(project: Project) {
     val artifacts = project.registerArtifacts(includeProtoJar, includeTestJar, includeDokkaJar)
     val publication = MavenJavaPublication(
         artifactId = artifactId,

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -363,7 +363,7 @@ open class SpinePublishing(private val project: Project) {
      * It consists of a project's name and [prefix][artifactPrefix]:
      * `<artifactPrefix><project.name>`.
      */
-    internal fun artifactId(project: Project): String = "$artifactPrefix${project.name}"
+    fun artifactId(project: Project): String = "$artifactPrefix${project.name}"
 
     /**
      * Ensures that all modules, marked as excluded from [protoJar] publishing,

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -28,8 +28,11 @@ package io.spine.internal.gradle.publish
 
 import io.spine.internal.gradle.Repository
 import org.gradle.api.Project
+import org.gradle.api.publish.PublicationContainer
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.getByType
 
 /**
  * Configures [SpinePublishing] extension.
@@ -116,8 +119,9 @@ fun Project.spinePublishing(configuration: SpinePublishing.() -> Unit) {
 /**
  * A Gradle extension for setting up publishing of spine modules using `maven-publish` plugin.
  *
- * @param project a project in which the extension is opened. By default, this project will be
- *  published as long as a [set][modules] of modules to publish is not specified explicitly.
+ * @param project
+ *         a project in which the extension is opened. By default, this project will be
+ *         published as long as a [set][modules] of modules to publish is not specified explicitly.
  *
  * @see spinePublishing
  */
@@ -139,6 +143,13 @@ open class SpinePublishing(private val project: Project) {
      * Empty by default.
      */
     var modules: Set<String> = emptySet()
+
+    /**
+     * Set of modules that have custom publications and do not need standard ones.
+     *
+     * Empty by default.
+     */
+    var modulesWithCustomPublishing: Set<String> = emptySet()
 
     /**
      * Set of repositories, to which the resulting artifacts will be sent.
@@ -274,7 +285,6 @@ open class SpinePublishing(private val project: Project) {
      * `maven-publish` plugin for each published module.
      */
     internal fun configured() {
-
         ensureProtoJarExclusionsArePublished()
         ensureTestJarInclusionsArePublished()
         ensuresModulesNotDuplicated()
@@ -309,8 +319,8 @@ open class SpinePublishing(private val project: Project) {
     /**
      * Sets up `maven-publish` plugin for the given project.
      *
-     * Firstly, an instance of [PublishingConfig] is assembled for the project. Then, this
-     * config is applied.
+     * Firstly, an instance of [PublishingConfig] is assembled for the project.
+     * Then, this config is applied.
      *
      * This method utilizes `project.afterEvaluate` closure. General rule of thumb is to avoid using
      * of this closure, as it configures a project when its configuration is considered completed.
@@ -380,8 +390,10 @@ open class SpinePublishing(private val project: Project) {
     private fun ensureTestJarInclusionsArePublished() {
         val nonPublishedInclusions = testJar.inclusions.minus(modules)
         if (nonPublishedInclusions.isNotEmpty()) {
-            throw IllegalStateException("One or more modules are marked as `included into test " +
-                    "JAR publication`, but they are not even published: $nonPublishedInclusions")
+            error(
+                "One or more modules are marked as `included into test JAR publication`," +
+                        " but they are not even published: $nonPublishedInclusions."
+            )
         }
     }
 
@@ -401,9 +413,22 @@ open class SpinePublishing(private val project: Project) {
         rootExtension?.let { rootPublishing ->
             val thisProject = setOf(project.name, project.path)
             if (thisProject.minus(rootPublishing.modules).size != 2) {
-                throw IllegalStateException("Publishing of `$thisProject` module is already " +
-                            "configured in a root project!")
+                error(
+                    "Publishing of `$thisProject` module is already configured in a root project!"
+                )
             }
         }
     }
 }
+
+/**
+ * Obtains [PublishingExtension] of this project.
+ */
+internal val Project.publishingExtension: PublishingExtension
+    get() = extensions.getByType()
+
+/**
+ * Obtains [PublicationContainer] of this project.
+ */
+internal val Project.publications: PublicationContainer
+    get() = publishingExtension.publications

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/PomFormatting.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/PomFormatting.kt
@@ -28,6 +28,7 @@ package io.spine.internal.gradle.report.pom
 
 import java.io.StringWriter
 import java.lang.System.lineSeparator
+import java.util.*
 
 /**
  * Helps to format the `pom.xml` file according to its expected XML structure.
@@ -74,6 +75,7 @@ internal object PomFormatting {
                     "structure per-subproject." +
                     NL
         return String.format(
+            Locale.US,
             "<!-- %s %s %s -->",
             NL, description, NL
         )

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/ScopedDependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/ScopedDependency.kt
@@ -94,16 +94,16 @@ private constructor(
          */
         fun of(dependency: Dependency, configuration: Configuration): ScopedDependency {
             val configurationName = configuration.name
-
-            if (CONFIG_TO_SCOPE.containsKey(configurationName)) {
-                val scope = CONFIG_TO_SCOPE[configurationName]
-                return ScopedDependency(dependency, scope!!)
+            val knownScope = CONFIG_TO_SCOPE[configurationName]
+            return when {
+                knownScope != null -> ScopedDependency(dependency, knownScope)
+                isTestsRelated(configurationName) -> ScopedDependency(dependency, test)
+                else -> ScopedDependency(dependency, undefined)
             }
-            if (configurationName.toLowerCase().startsWith("test")) {
-                return ScopedDependency(dependency, test)
-            }
-            return ScopedDependency(dependency, undefined)
         }
+
+        private fun isTestsRelated(configurationName: String): Boolean =
+            configurationName.startsWith("test", ignoreCase = true)
 
         /**
          * Performs comparison of {@code DependencyWithScope} instances according to these rules:

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
@@ -62,10 +62,8 @@ import io.spine.internal.gradle.publish.testJar
 @Suppress("unused")
 fun Project.exposeTestConfiguration() {
 
-    if (pluginManager.hasPlugin("java").not()) {
-        throw IllegalStateException(
-            "Can't expose the test configuration because `java` plugin has not been applied."
-        )
+    check(pluginManager.hasPlugin("java")) {
+        "Can't expose the test configuration because `java` plugin has not been applied."
     }
 
     configurations.create("testArtifacts") {

--- a/buildSrc/src/main/kotlin/io/spine/internal/markup/MarkdownDocument.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/markup/MarkdownDocument.kt
@@ -29,15 +29,11 @@ package io.spine.internal.markup
 import java.io.File
 
 /**
- * Shortcuts for the Markdown syntax.
- */
-
-/**
  * A virtual document written in Markdown.
  *
  * After it's finished, end-users would typically write it to a [real file][writeToFile].
  */
-@SuppressWarnings("detekt.complexity.TooManyFunctions")     /* By design. */
+@Suppress("TooManyFunctions")
 class MarkdownDocument {
 
     private val builder: StringBuilder = StringBuilder()

--- a/java-bundle/build.gradle.kts
+++ b/java-bundle/build.gradle.kts
@@ -38,7 +38,7 @@ val spinePublishing = rootProject.the<SpinePublishing>()
 /**
  * The ID of the far JAR artifact.
  */
-val pArtifact = spinePublishing.artifactPrefix + "java-extensions"
+val pArtifact = spinePublishing.artifactPrefix + "java-bundle"
 
 dependencies {
     implementation(project(":java"))
@@ -49,7 +49,7 @@ publishing {
     val pVersion = project.version.toString()
 
     publications {
-        create("fat-jar", MavenPublication::class) {
+        create("fatJar", MavenPublication::class) {
             groupId = pGroup
             artifactId = pArtifact
             version = pVersion
@@ -94,4 +94,12 @@ tasks.shadowJar {
     archiveClassifier.set("")    /** To prevent Gradle setting something like `osx-x86_64`. */
     mergeServiceFiles("desc.ref")
     mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")
+}
+
+/**
+ * Declare dependency explicitly to address the Gradle warning.
+ */
+val publishFatJarPublicationToMavenLocal: Task by tasks.getting {
+    dependsOn(tasks.jar)
+    println("Task `${this.name}` now depends on `${tasks.jar.name}`.")
 }

--- a/java-bundle/build.gradle.kts
+++ b/java-bundle/build.gradle.kts
@@ -28,11 +28,9 @@ import io.spine.internal.gradle.publish.SpinePublishing
 
 plugins {
     `maven-publish`
-    id("com.github.johnrengelman.shadow").version("7.1.2")
+    id("com.github.johnrengelman.shadow")
     java
 }
-
-/** The publishing settings from the root project. */
 
 dependencies {
     implementation(project(":java"))

--- a/java-bundle/build.gradle.kts
+++ b/java-bundle/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.spine.internal.gradle.publish.SpinePublishing
-
 /*
  * Copyright 2022, TeamDev. All rights reserved.
  *
@@ -27,77 +25,9 @@ import io.spine.internal.gradle.publish.SpinePublishing
  */
 
 plugins {
-    `maven-publish`
-    id("com.github.johnrengelman.shadow")
-    java
+    `fat-jar`
 }
 
 dependencies {
     implementation(project(":java"))
-}
-
-/**
- * Creates a custom publication called `fatJar`, taking the output of `tasks.shadowJar`
- * as the sole publication artifact.
- *
- * This publication works in combination with exclusion of standard publishing for this
- * module specified in the root project under [SpinePublishing.modulesWithCustomPublishing].
- */
-publishing {
-    publications {
-        // The publishing settings from the root project.
-        val spinePublishing = rootProject.the<SpinePublishing>()
-        create("fatJar", MavenPublication::class) {
-            groupId = project.group.toString()
-            artifactId = spinePublishing.artifactId(project)
-            version = project.version.toString()
-            artifact(tasks.shadowJar)
-        }
-    }
-}
-
-tasks.publish {
-    dependsOn(tasks.shadowJar)
-}
-
-tasks.shadowJar {
-    exclude(
-        /**
-         * Excluding this type to avoid it being located in the fat JAR.
-         *
-         * Locating this type in its own `io:spine:protodata` artifact is crucial
-         * for obtaining proper version values from the manifest file.
-         * This file is only present in `io:spine:protodata` artifact.
-         */
-        "io/spine/protodata/gradle/plugin/Plugin.class",
-        "META-INF/gradle-plugins/io.spine.protodata.properties",
-
-        /**
-         * Exclude Gradle types to reduce the size of the resulting JAR.
-         *
-         * Those required for the plugins are available at runtime anyway.
-         */
-        "org/gradle/**",
-
-        /**
-         * Remove all third-party plugin declarations as well.
-         *
-         * They should be loaded from their respective dependencies.
-         */
-        "META-INF/gradle-plugins/com**",
-        "META-INF/gradle-plugins/net**",
-        "META-INF/gradle-plugins/org**")
-
-    isZip64 = true  /* The archive has way too many items. So using the Zip64 mode. */
-    archiveClassifier.set("")    /** To prevent Gradle setting something like `osx-x86_64`. */
-    mergeServiceFiles("desc.ref")
-    mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")
-}
-
-/**
- * Declare dependency explicitly to address the Gradle warning.
- */
-val publishFatJarPublicationToMavenLocal: Task by tasks.getting {
-    dependsOn(tasks.jar)
-    println("Task `${this.name}` now depends on `${tasks.jar.name}`.")
 }

--- a/java-bundle/build.gradle.kts
+++ b/java-bundle/build.gradle.kts
@@ -33,26 +33,26 @@ plugins {
 }
 
 /** The publishing settings from the root project. */
-val spinePublishing = rootProject.the<SpinePublishing>()
-
-/**
- * The ID of the far JAR artifact.
- */
-val pArtifact = spinePublishing.artifactPrefix + "java-bundle"
 
 dependencies {
     implementation(project(":java"))
 }
 
+/**
+ * Creates a custom publication called `fatJar`, taking the output of `tasks.shadowJar`
+ * as the sole publication artifact.
+ *
+ * This publication works in combination with exclusion of standard publishing for this
+ * module specified in the root project under [SpinePublishing.modulesWithCustomPublishing].
+ */
 publishing {
-    val pGroup = project.group.toString()
-    val pVersion = project.version.toString()
-
     publications {
+        // The publishing settings from the root project.
+        val spinePublishing = rootProject.the<SpinePublishing>()
         create("fatJar", MavenPublication::class) {
-            groupId = pGroup
-            artifactId = pArtifact
-            version = pVersion
+            groupId = project.group.toString()
+            artifactId = spinePublishing.artifactId(project)
+            version = project.version.toString()
             artifact(tasks.shadowJar)
         }
     }
@@ -90,7 +90,7 @@ tasks.shadowJar {
         "META-INF/gradle-plugins/net**",
         "META-INF/gradle-plugins/org**")
 
-    setZip64(true)  /* The archive has way too many items. So using the Zip64 mode. */
+    isZip64 = true  /* The archive has way too many items. So using the Zip64 mode. */
     archiveClassifier.set("")    /** To prevent Gradle setting something like `osx-x86_64`. */
     mergeServiceFiles("desc.ref")
     mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")

--- a/java-runtime-bundle/build.gradle.kts
+++ b/java-runtime-bundle/build.gradle.kts
@@ -36,23 +36,21 @@ dependencies {
     api(project(":java-runtime"))
 }
 
-/** The publishing settings from the root project. */
-val spinePublishing = rootProject.the<SpinePublishing>()
-
 /**
- * The ID of the far JAR artifact.
+ * Creates a custom publication called `fatJar`, taking the output of `tasks.shadowJar`
+ * as the sole publication artifact.
+ *
+ * This publication works in combination with exclusion of standard publishing for this
+ * module specified in the root project under [SpinePublishing.modulesWithCustomPublishing].
  */
-val pArtifact = spinePublishing.artifactPrefix + "java-runtime-bundle"
-
 publishing {
-    val pGroup = project.group.toString()
-    val pVersion = project.version.toString()
-
     publications {
+        // The publishing settings from the root project.
+        val spinePublishing = rootProject.the<SpinePublishing>()
         create("fatJar", MavenPublication::class) {
-            groupId = pGroup
-            artifactId = pArtifact
-            version = pVersion
+            groupId = project.group.toString()
+            artifactId = spinePublishing.artifactId(project)
+            version = project.version.toString()
             artifact(tasks.shadowJar)
         }
     }
@@ -80,7 +78,7 @@ tasks.shadowJar {
         "META-INF/gradle-plugins/net**",
         "META-INF/gradle-plugins/org**")
 
-    setZip64(true)  /* The archive has way too many items. So using the Zip64 mode. */
+    isZip64 = true  /* The archive has way too many items. So using the Zip64 mode. */
     archiveClassifier.set("")    /** To prevent Gradle setting something like `osx-x86_64`. */
     mergeServiceFiles("desc.ref")
     mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")

--- a/java-runtime-bundle/build.gradle.kts
+++ b/java-runtime-bundle/build.gradle.kts
@@ -87,8 +87,9 @@ tasks.shadowJar {
 }
 
 /**
- * Declare dependency explicitly to avoid the Gradle warning.
+ * Declare dependency explicitly to address the Gradle warning.
  */
-tasks.withType<PublishToMavenRepository>().configureEach {
+val publishFatJarPublicationToMavenLocal: Task by tasks.getting {
     dependsOn(tasks.jar)
+    println("Task `${this.name}` now depends on `${tasks.jar.name}`.")
 }

--- a/java-runtime-bundle/build.gradle.kts
+++ b/java-runtime-bundle/build.gradle.kts
@@ -24,70 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.internal.gradle.publish.SpinePublishing
-
 plugins {
-    `maven-publish`
-    id("com.github.johnrengelman.shadow")
-    java
+    `fat-jar`
 }
 
 dependencies {
     api(project(":java-runtime"))
-}
-
-/**
- * Creates a custom publication called `fatJar`, taking the output of `tasks.shadowJar`
- * as the sole publication artifact.
- *
- * This publication works in combination with exclusion of standard publishing for this
- * module specified in the root project under [SpinePublishing.modulesWithCustomPublishing].
- */
-publishing {
-    publications {
-        // The publishing settings from the root project.
-        val spinePublishing = rootProject.the<SpinePublishing>()
-        create("fatJar", MavenPublication::class) {
-            groupId = project.group.toString()
-            artifactId = spinePublishing.artifactId(project)
-            version = project.version.toString()
-            artifact(tasks.shadowJar)
-        }
-    }
-}
-
-tasks.publish {
-    dependsOn(tasks.shadowJar)
-}
-
-tasks.shadowJar {
-    exclude(
-        /**
-         * Exclude Gradle types to reduce the size of the resulting JAR.
-         *
-         * Those required for the plugins are available at runtime anyway.
-         */
-        "org/gradle/**",
-
-        /**
-         * Remove all third-party plugin declarations as well.
-         *
-         * They should be loaded from their respective dependencies.
-         */
-        "META-INF/gradle-plugins/com**",
-        "META-INF/gradle-plugins/net**",
-        "META-INF/gradle-plugins/org**")
-
-    isZip64 = true  /* The archive has way too many items. So using the Zip64 mode. */
-    archiveClassifier.set("")    /** To prevent Gradle setting something like `osx-x86_64`. */
-    mergeServiceFiles("desc.ref")
-    mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")
-}
-
-/**
- * Declare dependency explicitly to address the Gradle warning.
- */
-val publishFatJarPublicationToMavenLocal: Task by tasks.getting {
-    dependsOn(tasks.jar)
-    println("Task `${this.name}` now depends on `${tasks.jar.name}`.")
 }

--- a/license-report.md
+++ b/license-report.md
@@ -728,7 +728,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:19 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1461,7 +1461,7 @@ This report was generated on **Thu Nov 03 09:26:19 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:20 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2091,7 +2091,7 @@ This report was generated on **Thu Nov 03 09:26:20 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:20 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2670,7 +2670,7 @@ This report was generated on **Thu Nov 03 09:26:20 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:21 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3466,7 +3466,7 @@ This report was generated on **Thu Nov 03 09:26:21 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:21 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4184,7 +4184,7 @@ This report was generated on **Thu Nov 03 09:26:21 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4959,7 +4959,7 @@ This report was generated on **Thu Nov 03 09:26:22 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5728,7 +5728,7 @@ This report was generated on **Thu Nov 03 09:26:22 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6497,7 +6497,7 @@ This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7172,7 +7172,7 @@ This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7795,7 +7795,7 @@ This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8546,4 +8546,4 @@ This report was generated on **Thu Nov 03 09:26:24 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:26:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -728,12 +728,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:53 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:51 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1461,12 +1461,12 @@ This report was generated on **Wed Nov 02 00:27:53 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:52 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2091,12 +2091,12 @@ This report was generated on **Wed Nov 02 00:27:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:52 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime-bundle:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime-bundle:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2670,12 +2670,12 @@ This report was generated on **Wed Nov 02 00:27:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:53 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3466,12 +3466,12 @@ This report was generated on **Wed Nov 02 00:27:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4184,12 +4184,12 @@ This report was generated on **Wed Nov 02 00:27:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4959,12 +4959,12 @@ This report was generated on **Wed Nov 02 00:27:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -5728,12 +5728,12 @@ This report was generated on **Wed Nov 02 00:27:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -6497,12 +6497,12 @@ This report was generated on **Wed Nov 02 00:27:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7172,12 +7172,12 @@ This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7795,12 +7795,12 @@ This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.60`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -8546,4 +8546,4 @@ This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 00:27:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -728,7 +728,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:51 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:19 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1461,7 +1461,7 @@ This report was generated on **Wed Nov 02 18:43:51 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:52 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:20 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2091,7 +2091,7 @@ This report was generated on **Wed Nov 02 18:43:52 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:52 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:20 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2670,7 +2670,7 @@ This report was generated on **Wed Nov 02 18:43:52 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:53 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:21 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3466,7 +3466,7 @@ This report was generated on **Wed Nov 02 18:43:53 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:21 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4184,7 +4184,7 @@ This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4959,7 +4959,7 @@ This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5728,7 +5728,7 @@ This report was generated on **Wed Nov 02 18:43:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6497,7 +6497,7 @@ This report was generated on **Wed Nov 02 18:43:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7172,7 +7172,7 @@ This report was generated on **Wed Nov 02 18:43:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7795,7 +7795,7 @@ This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8546,4 +8546,4 @@ This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 02 18:43:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 09:26:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -728,7 +728,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1461,7 +1461,7 @@ This report was generated on **Thu Nov 03 09:49:22 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:22 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2091,7 +2091,7 @@ This report was generated on **Thu Nov 03 09:49:22 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2670,7 +2670,7 @@ This report was generated on **Thu Nov 03 09:49:23 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:23 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3466,7 +3466,7 @@ This report was generated on **Thu Nov 03 09:49:23 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:27 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4184,7 +4184,7 @@ This report was generated on **Thu Nov 03 09:49:24 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:24 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:27 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4959,7 +4959,7 @@ This report was generated on **Thu Nov 03 09:49:24 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:27 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5728,7 +5728,7 @@ This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6497,7 +6497,7 @@ This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7172,7 +7172,7 @@ This report was generated on **Thu Nov 03 09:49:25 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7795,7 +7795,7 @@ This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8546,4 +8546,4 @@ This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 03 09:49:26 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 03 11:42:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.51</version>
+<version>2.0.0-SNAPSHOT.60</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -41,7 +41,6 @@ all modules and does not describe the project structure per-subproject.
     <version>3.19.6</version>
     <scope>compile</scope>
   </dependency>
-  //
   <dependency>
     <groupId>com.squareup</groupId>
     <artifactId>javapoet</artifactId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.51")
+val validationVersion by extra("2.0.0-SNAPSHOT.52")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.52")
+val validationVersion by extra("2.0.0-SNAPSHOT.60")


### PR DESCRIPTION
This PR:
  * Extracts publishing of `fatJar` artifact into `fat-jar` scripting plugin.
  * Extends `spinePublishing` with the ability to handle custom publications, introducing `modulesWithCustomPublishing` property.
  * Applies Gradle Shadow plugin at `buildScript/.../build.gradle.kts` level so that `fat-jar` script plugin is possible.

The version is set to `2.0.0-SNAPSHOT.60` to jump over `5x` artifacts that were not successfully published because of errors in the previous PRs.

Once this PR is merged and new publishing is fully tested, the extensions introduced in this PR to common publishing schema would be added to `config`.