### PR TITLE
Enable codegen-related tests back

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.170"
+        const val mcJava = "2.0.0-SNAPSHOT.173"
 
         /**
          * The version of [Spine.baseTypes].

--- a/java-runtime/build.gradle.kts
+++ b/java-runtime/build.gradle.kts
@@ -42,14 +42,6 @@ dependencies {
     testImplementation(Spine.testlib)
 }
 
-modelCompiler {
-    java {
-        codegen {
-            validation { skipValidation() }
-        }
-    }
-}
-
 // Uncomment the below block when remote debugging of code generation is needed.
 //
 //tasks.findByName("launchTestProtoData")?.apply {this as JavaExec

--- a/java-runtime/src/test/java/io/spine/validate/IfMissingErrorMsgSpec.kt
+++ b/java-runtime/src/test/java/io/spine/validate/IfMissingErrorMsgSpec.kt
@@ -36,14 +36,12 @@ import io.spine.test.validate.CustomMessageRequiredMsgFieldValue
 import io.spine.test.validate.CustomMessageRequiredRepeatedMsgFieldValue
 import io.spine.test.validate.CustomMessageRequiredStringFieldValue
 import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 @DisplayName(VALIDATION_SHOULD + "use `if_missing` field option")
-@Disabled("Until 'skipValidation()` is turned off.")
 internal class IfMissingErrorMsgSpec : ValidationOfConstraintTest() {
 
     @Nested inner class

--- a/java-runtime/src/test/java/io/spine/validate/OneofSpec.kt
+++ b/java-runtime/src/test/java/io/spine/validate/OneofSpec.kt
@@ -35,7 +35,6 @@ import io.spine.test.validate.oneof.RequiredOneofWithValidation
 import io.spine.test.validate.oneof.oneofWithValidation
 import io.spine.test.validate.oneof.requiredOneofWithValidation
 import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -118,7 +117,6 @@ internal class OneofSpec : ValidationOfConstraintTest() {
         }
 
         @Test
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `a field within 'oneof' is not valid`() = assertDoesNotBuild {
             OneofWithValidation.newBuilder()
                 .setWithValidation("   ")
@@ -130,7 +128,6 @@ internal class OneofSpec : ValidationOfConstraintTest() {
             assertNotValid(OneofWithRequiredFields.getDefaultInstance(), false)
 
         @Test
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `a required field is not valid`() = assertDoesNotBuild {
             RequiredOneofWithValidation.newBuilder()
                 .setValidValue("###")

--- a/java-runtime/src/test/java/io/spine/validate/option/RequiredSpec.kt
+++ b/java-runtime/src/test/java/io/spine/validate/option/RequiredSpec.kt
@@ -45,7 +45,6 @@ import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
 import io.spine.validate.given.MessageValidatorTestEnv
 import io.spine.validate.given.MessageValidatorTestEnv.newByteString
 import io.spine.validate.given.MessageValidatorTestEnv.newStringValue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -85,7 +84,6 @@ internal class RequiredSpec : ValidationOfConstraintTest() {
     }
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `find out that required 'ByteString' field is NOT set`() {
         assertCheckFails(
             RequiredBytes.getDefaultInstance()

--- a/java-runtime/src/test/kotlin/io/spine/validate/AnyValidationSpec.kt
+++ b/java-runtime/src/test/kotlin/io/spine/validate/AnyValidationSpec.kt
@@ -33,7 +33,6 @@ import io.spine.test.validate.anyfields.UncheckedAnyContainer
 import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
 import io.spine.validate.given.MessageValidatorTestEnv.newStringValue
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -68,7 +67,6 @@ internal class AnyValidationSpec : ValidationOfConstraintTest() {
             .setAny(AnyPacker.pack(invalidMessage))
 
         @Test
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `on 'build()' method`() {
             assertThrows<ValidationException> {
                 builder.build()
@@ -108,7 +106,6 @@ internal class AnyValidationSpec : ValidationOfConstraintTest() {
             assertNotValid(builder.buildPartial())
 
         @Test
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `on 'build()' method`() {
             assertThrows<ValidationException> { builder.build() }
         }

--- a/java-runtime/src/test/kotlin/io/spine/validate/EnclosedMessageValidationSpec.kt
+++ b/java-runtime/src/test/kotlin/io/spine/validate/EnclosedMessageValidationSpec.kt
@@ -40,7 +40,6 @@ import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
 import io.spine.validate.given.MessageValidatorTestEnv.EMAIL
 import io.spine.validate.given.MessageValidatorTestEnv.ENCLOSED_FIELD_NAME
 import io.spine.validate.given.MessageValidatorTestEnv.assertFieldPathIs
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -89,7 +88,6 @@ internal class EnclosedMessageValidationSpec : ValidationOfConstraintTest() {
     }
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `provide valid violations if enclosed message field is not valid`() {
         val enclosedMsg = PatternStringFieldValue.newBuilder()
             .setEmail("invalid email")
@@ -120,7 +118,6 @@ internal class EnclosedMessageValidationSpec : ValidationOfConstraintTest() {
     }
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `provide custom invalid field message if specified`() {
         val enclosedMsg: @NonValidated PatternStringFieldValue =
             PatternStringFieldValue.newBuilder()

--- a/java-runtime/src/test/kotlin/io/spine/validate/NumberRangeSpec.kt
+++ b/java-runtime/src/test/kotlin/io/spine/validate/NumberRangeSpec.kt
@@ -37,7 +37,6 @@ import io.spine.test.validate.MinInclusive
 import io.spine.type.TypeName
 import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
 import io.spine.validate.given.MessageValidatorTestEnv.VALUE
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -75,7 +74,6 @@ internal class NumberRangeSpec : ValidationOfConstraintTest() {
         minNumberTest(LESS_THAN_MIN, inclusive = false, valid = false)
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `provide one valid violation if number is less than min`() {
         minNumberTest(LESS_THAN_MIN, inclusive = true, valid = false)
         assertSingleViolation(LESS_MIN_MSG, VALUE)
@@ -106,7 +104,6 @@ internal class NumberRangeSpec : ValidationOfConstraintTest() {
         maxNumberTest(LESS_THAN_MAX, inclusive = false, valid = true)
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `provide one valid violation if number is greater than max`() {
         maxNumberTest(GREATER_THAN_MAX, inclusive = true, valid = false)
         assertSingleViolation(
@@ -116,7 +113,6 @@ internal class NumberRangeSpec : ValidationOfConstraintTest() {
     }
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `not allow fraction boundaries for integer fields`() {
         val exception = assertThrows<ValidationException> {
             InvalidBound.newBuilder().build()

--- a/java-runtime/src/test/kotlin/io/spine/validate/option/DistinctSpec.kt
+++ b/java-runtime/src/test/kotlin/io/spine/validate/option/DistinctSpec.kt
@@ -32,7 +32,6 @@ import io.spine.test.validate.DistinctValues.Planet.JUPITER
 import io.spine.test.validate.DistinctValues.Planet.MARS
 import io.spine.test.validate.distinctValues
 import io.spine.validate.ValidationOfConstraintTest
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -86,10 +85,8 @@ internal class DistinctSpec : ValidationOfConstraintTest() {
         }
     }
 
-    @Nested
-    @DisplayName("find out that duplicate value violates contract")
-    @Disabled("Until 'skipValidation()` is turned off.")
-    internal inner class DuplicateViolates {
+    @Nested internal inner class
+    `find out that duplicate value violates contract` {
 
         @Test
         fun enums() = assertDoesNotBuild {

--- a/java-runtime/src/test/kotlin/io/spine/validate/option/IsRequiredSpec.kt
+++ b/java-runtime/src/test/kotlin/io/spine/validate/option/IsRequiredSpec.kt
@@ -34,7 +34,6 @@ import io.spine.testing.TestValues.randomString
 import io.spine.validate.ValidationException
 import io.spine.validate.ValidationOfConstraintTest
 import io.spine.validate.ValidationOfConstraintTest.Companion.VALIDATION_SHOULD
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.assertThrows
 internal class IsRequiredSpec : ValidationOfConstraintTest() {
 
     @Test
-    @Disabled("Until 'skipValidation()` is turned off.")
     fun `throw if required field group is not set`() {
         val exception = assertThrows<ValidationException> {
             meal {

--- a/java-runtime/src/test/kotlin/io/spine/validate/option/RangeSpec.kt
+++ b/java-runtime/src/test/kotlin/io/spine/validate/option/RangeSpec.kt
@@ -38,7 +38,6 @@ import java.util.stream.IntStream
 import java.util.stream.LongStream
 import java.util.stream.Stream
 import kotlin.streams.toList
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -61,7 +60,6 @@ internal class RangeSpec : ValidationOfConstraintTest() {
 
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeSpec#invalidHours")
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `do not fit into the defined range`(hour: Int) = assertDoesNotBuild {
             hourRange(hour)
         }
@@ -80,7 +78,6 @@ internal class RangeSpec : ValidationOfConstraintTest() {
 
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeSpec#invalidMinutes")
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `do not fit into the defined range`(minute: Long) = assertDoesNotBuild {
             minuteRange(minute)
         }
@@ -100,7 +97,6 @@ internal class RangeSpec : ValidationOfConstraintTest() {
 
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeSpec#invalidDegrees")
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `do not fit into the defined range`(degree: Float) = assertDoesNotBuild {
             floatRange(degree)
         }
@@ -120,7 +116,6 @@ internal class RangeSpec : ValidationOfConstraintTest() {
 
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeSpec#invalidAngles")
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun `do not fit into the defined range`(angle: Double) = assertDoesNotBuild {
             doubleRange(angle)
         }
@@ -141,7 +136,6 @@ internal class RangeSpec : ValidationOfConstraintTest() {
         }
 
         @Test
-        @Disabled("Until 'skipValidation()` is turned off.")
         fun invalid() = assertDoesNotBuild {
             Hours.newBuilder()
                 .addAllHour(invalidHours().toList())

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -799,12 +799,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:39 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -1569,12 +1569,12 @@ This report was generated on **Mon Nov 20 13:58:39 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:39 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1798,7 +1798,7 @@ This report was generated on **Mon Nov 20 13:58:39 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.24.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1931,7 +1931,7 @@ This report was generated on **Mon Nov 20 13:58:39 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://detekt.dev](https://detekt.dev)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -2239,12 +2239,12 @@ This report was generated on **Mon Nov 20 13:58:39 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:40 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:02 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime-bundle:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime-bundle:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2837,12 +2837,12 @@ This report was generated on **Mon Nov 20 13:58:40 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:41 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:02 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -3336,7 +3336,7 @@ This report was generated on **Mon Nov 20 13:58:41 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3683,12 +3683,12 @@ This report was generated on **Mon Nov 20 13:58:41 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:41 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4490,12 +4490,12 @@ This report was generated on **Mon Nov 20 13:58:41 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -4820,11 +4820,6 @@ This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.24.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
@@ -4990,7 +4985,7 @@ This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -5302,12 +5297,12 @@ This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6116,12 +6111,12 @@ This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -6612,7 +6607,7 @@ This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -6901,12 +6896,12 @@ This report was generated on **Mon Nov 20 13:58:42 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extra-definitions:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-extra-definitions:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7296,7 +7291,7 @@ This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -7579,12 +7574,12 @@ This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8289,12 +8284,12 @@ This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8511,7 +8506,7 @@ This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.24.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8644,7 +8639,7 @@ This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://detekt.dev](https://detekt.dev)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -8918,12 +8913,12 @@ This report was generated on **Mon Nov 20 13:58:43 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:44 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.**No license information found**
@@ -9248,7 +9243,7 @@ This report was generated on **Mon Nov 20 13:58:44 WET 2023** using [Gradle-Lice
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.24.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -9413,7 +9408,7 @@ This report was generated on **Mon Nov 20 13:58:44 WET 2023** using [Gradle-Lice
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.57.2.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.59.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -9701,4 +9696,4 @@ This report was generated on **Mon Nov 20 13:58:44 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 20 13:58:44 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 20 18:34:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.111</version>
+<version>2.0.0-SNAPSHOT.112</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -86,7 +86,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.104</version>
+    <version>2.0.0-SNAPSHOT.111</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -202,7 +202,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>protoc-gen-grpc-java</artifactId>
-    <version>1.57.2</version>
+    <version>1.59.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
@@ -222,38 +222,38 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-annotation</artifactId>
-    <version>2.0.0-SNAPSHOT.170</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-base</artifactId>
-    <version>2.0.0-SNAPSHOT.170</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.170</version>
+    <version>2.0.0-SNAPSHOT.173</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.170</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-rejection</artifactId>
-    <version>2.0.0-SNAPSHOT.170</version>
+    <version>2.0.0-SNAPSHOT.173</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.184</version>
+    <version>2.0.0-SNAPSHOT.187</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.104</version>
+    <version>2.0.0-SNAPSHOT.111</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/proto/configuration/build.gradle.kts
+++ b/proto/configuration/build.gradle.kts
@@ -34,13 +34,3 @@ dependencies {
     implementation(Spine.base)
     implementation(project(":java-runtime"))
 }
-
-modelCompiler {
-    java {
-        codegen {
-            validation {
-                skipValidation()
-            }
-        }
-    }
-}

--- a/proto/context/build.gradle.kts
+++ b/proto/context/build.gradle.kts
@@ -37,16 +37,6 @@ dependencies {
     implementation(project(":java-runtime"))
 }
 
-modelCompiler {
-    java {
-        codegen {
-            validation {
-                skipValidation()
-            }
-        }
-    }
-}
-
 // Uncomment the below block when remote debugging of code generation is needed.
 //
 //tasks.findByName("launchProtoData")?.apply {this as JavaExec

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.111")
+val validationVersion by extra("2.0.0-SNAPSHOT.112")


### PR DESCRIPTION
This PR concludes the first round of enabling codegen features started by #107:
 * `skipValidation()` blocks were removed.
 * Tests disabled bin #107 were enabled back.