### PR TITLE
Migrate to new `Plugin` API

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -39,10 +39,10 @@ object McJava {
     const val group = Spine.toolsGroup
 
     /** The version used to in the build classpath. */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.243"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.244"
 
     /** The version to be used for integration tests. */
-    const val version = "2.0.0-SNAPSHOT.243"
+    const val version = "2.0.0-SNAPSHOT.244"
 
     const val pluginId = "io.spine.mc-java"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -42,7 +42,7 @@ object McJava {
     const val dogfoodingVersion = "2.0.0-SNAPSHOT.244"
 
     /** The version to be used for integration tests. */
-    const val version = "2.0.0-SNAPSHOT.244"
+    const val version = "2.0.0-SNAPSHOT.247"
 
     const val pluginId = "io.spine.mc-java"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.4"
+    private const val fallbackVersion = "0.61.6"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.4"
+    private const val fallbackDfVersion = "0.61.6"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.6"
+    private const val fallbackVersion = "0.61.8"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.6"
+    private const val fallbackDfVersion = "0.61.8"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.62.0"
+    private const val fallbackVersion = "0.63.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.62.0"
+    private const val fallbackDfVersion = "0.61.8"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.63.1"
+    private const val fallbackVersion = "0.63.2"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.8"
+    private const val fallbackVersion = "0.62.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.8"
+    private const val fallbackDfVersion = "0.62.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -76,7 +76,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.176"
+        const val core = "2.0.0-SNAPSHOT.177"
 
         /**
          * The version of [Spine.modelCompiler].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,8 +45,8 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.212"
-        const val baseForBuildScript = "2.0.0-SNAPSHOT.212"
+        const val base = "2.0.0-SNAPSHOT.215"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.215"
 
         /**
          * The version of [Spine.reflect].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -53,21 +53,21 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
          */
-        const val reflect = "2.0.0-SNAPSHOT.188"
+        const val reflect = "2.0.0-SNAPSHOT.190"
 
         /**
          * The version of [Spine.Logging].
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.233"
+        const val logging = "2.0.0-SNAPSHOT.240"
 
         /**
          * The version of [Spine.testlib].
          *
          * @see <a href="https://github.com/SpineEventEngine/testlib">spine-testlib</a>
          */
-        const val testlib = "2.0.0-SNAPSHOT.184"
+        const val testlib = "2.0.0-SNAPSHOT.185"
 
         /**
          * The version of `core-java`.
@@ -157,6 +157,7 @@ object Spine {
     object Logging {
         const val version = ArtifactVersion.logging
         const val lib = "$group:spine-logging:$version"
+        const val libJvm = "$group:spine-logging-jvm:$version"
 
         const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
         const val stdContext = "$group:spine-logging-std-context:$version"
@@ -166,7 +167,7 @@ object Spine {
         // Transitive dependencies.
         // Make `public` and use them to force a version in a particular repository, if needed.
         internal const val julBackend = "$group:spine-logging-jul-backend:$version"
-        internal const val middleware = "$group:spine-logging-middleware:$version"
+        const val middleware = "$group:spine-logging-middleware:$version"
         internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
         internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
     }

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import Module_gradle.Module
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.JUnit
@@ -152,6 +153,8 @@ fun Module.forceConfigurations() {
                     Spine.time,
                     Spine.testlib,
                     Spine.toolBase,
+                    Spine.Logging.libJvm,
+                    Spine.Logging.middleware,
                     Spine.server,
                     "io.spine.validation:spine-validation-java-runtime:$validationVersion",
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -852,12 +852,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1673,12 +1673,12 @@ This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2364,12 +2364,12 @@ This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime-bundle:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime-bundle:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2979,12 +2979,12 @@ This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3904,12 +3904,12 @@ This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4764,12 +4764,12 @@ This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5622,12 +5622,12 @@ This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6495,12 +6495,12 @@ This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7361,12 +7361,12 @@ This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extra-definitions:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-extra-definitions:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8082,12 +8082,12 @@ This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8842,12 +8842,12 @@ This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-validating-options:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-validating-options:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9481,12 +9481,12 @@ This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-validation:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-validation:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10202,12 +10202,12 @@ This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-validation-gen:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-validation-gen:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10966,12 +10966,12 @@ This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11721,12 +11721,12 @@ This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -12555,12 +12555,12 @@ This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.161`
+# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.162`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -13389,4 +13389,4 @@ This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 16:50:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -56,6 +56,10 @@
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -852,7 +856,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -913,6 +917,10 @@ This report was generated on **Wed Oct 16 19:26:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1673,7 +1681,7 @@ This report was generated on **Wed Oct 16 19:26:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1691,6 +1699,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -1719,6 +1731,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -1732,10 +1748,6 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2364,7 +2376,7 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2382,6 +2394,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -2410,6 +2426,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -2423,10 +2443,6 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2712,6 +2728,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://fastutil.di.unimi.it/](http://fastutil.di.unimi.it/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
      * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2979,7 +2999,7 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3040,6 +3060,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3904,7 +3928,7 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3965,6 +3989,10 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4764,7 +4792,7 @@ This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4823,6 +4851,10 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -5622,7 +5654,7 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5681,6 +5713,10 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -6495,7 +6531,7 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6554,6 +6590,10 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -7361,7 +7401,7 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7381,6 +7421,10 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7407,6 +7451,10 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -7420,10 +7468,6 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8082,7 +8126,7 @@ This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8102,6 +8146,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8128,6 +8176,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -8141,10 +8193,6 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -8842,7 +8890,7 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8862,6 +8910,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8888,6 +8940,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -8901,10 +8957,6 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -9481,7 +9533,7 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9501,6 +9553,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -9527,6 +9583,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -9540,10 +9600,6 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -10202,7 +10258,7 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10220,6 +10276,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -10248,6 +10308,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -10261,10 +10325,6 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -10966,7 +11026,7 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10984,6 +11044,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -11012,6 +11076,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
@@ -11025,10 +11093,6 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -11721,7 +11785,7 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11782,6 +11846,10 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -12555,7 +12623,7 @@ This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12616,6 +12684,10 @@ This report was generated on **Wed Oct 16 19:26:54 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -13389,4 +13461,4 @@ This report was generated on **Wed Oct 16 19:26:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 19:26:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -856,7 +856,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:36 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:36 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2376,7 +2376,7 @@ This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2999,7 +2999,7 @@ This report was generated on **Thu Oct 24 22:28:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3928,7 +3928,7 @@ This report was generated on **Thu Oct 24 22:28:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4792,7 +4792,7 @@ This report was generated on **Thu Oct 24 22:28:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5654,7 +5654,7 @@ This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6531,7 +6531,7 @@ This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7401,7 +7401,7 @@ This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8126,7 +8126,7 @@ This report was generated on **Thu Oct 24 22:28:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8890,7 +8890,7 @@ This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9533,7 +9533,7 @@ This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10258,7 +10258,7 @@ This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11026,7 +11026,7 @@ This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11785,7 +11785,7 @@ This report was generated on **Thu Oct 24 22:28:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12623,7 +12623,7 @@ This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13461,4 +13461,4 @@ This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 22:28:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 15:56:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -852,7 +852,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1673,7 +1673,7 @@ This report was generated on **Fri Oct 11 16:50:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2364,7 +2364,7 @@ This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2979,7 +2979,7 @@ This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3904,7 +3904,7 @@ This report was generated on **Fri Oct 11 16:50:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4764,7 +4764,7 @@ This report was generated on **Fri Oct 11 16:50:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5622,7 +5622,7 @@ This report was generated on **Fri Oct 11 16:50:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6495,7 +6495,7 @@ This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7361,7 +7361,7 @@ This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8082,7 +8082,7 @@ This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8842,7 +8842,7 @@ This report was generated on **Fri Oct 11 16:50:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9481,7 +9481,7 @@ This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10202,7 +10202,7 @@ This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10966,7 +10966,7 @@ This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11721,7 +11721,7 @@ This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12555,7 +12555,7 @@ This report was generated on **Fri Oct 11 16:50:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13389,4 +13389,4 @@ This report was generated on **Fri Oct 11 16:50:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 11 16:50:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 19:26:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -852,7 +852,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1673,7 +1673,7 @@ This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2364,7 +2364,7 @@ This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2979,7 +2979,7 @@ This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3904,7 +3904,7 @@ This report was generated on **Tue Oct 08 17:36:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4764,7 +4764,7 @@ This report was generated on **Tue Oct 08 17:36:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5622,7 +5622,7 @@ This report was generated on **Tue Oct 08 17:36:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6495,7 +6495,7 @@ This report was generated on **Tue Oct 08 17:36:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:17 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7361,7 +7361,7 @@ This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8082,7 +8082,7 @@ This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8842,7 +8842,7 @@ This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9481,7 +9481,7 @@ This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10202,7 +10202,7 @@ This report was generated on **Tue Oct 08 17:36:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10966,7 +10966,7 @@ This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11721,7 +11721,7 @@ This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12555,7 +12555,7 @@ This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13389,4 +13389,4 @@ This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 17:36:55 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 10 18:03:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java-tests/extensions/src/main/kotlin/io/spine/validation/test/CurrencyValidationPolicy.kt
+++ b/java-tests/extensions/src/main/kotlin/io/spine/validation/test/CurrencyValidationPolicy.kt
@@ -31,8 +31,9 @@ import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.event.TypeExited
 import io.spine.protodata.plugin.Policy
 import io.spine.protodata.value.Value
+import io.spine.server.event.NoReaction
 import io.spine.server.event.React
-import io.spine.server.model.Nothing
+import io.spine.server.event.asB
 import io.spine.server.query.select
 import io.spine.server.tuple.EitherOf2
 import io.spine.validation.ComparisonOperator.LESS_THAN
@@ -49,10 +50,10 @@ import io.spine.validation.test.money.CurrencyType
 public class CurrencyValidationPolicy : Policy<TypeExited>() {
 
     @React
-    override fun whenever(@External event: TypeExited): EitherOf2<SimpleRuleAdded, Nothing> {
+    override fun whenever(@External event: TypeExited): EitherOf2<SimpleRuleAdded, NoReaction> {
         val currencyType = select<CurrencyType>().findById(event.type)
         if (currencyType == null || currencyType.hasCurrency().not()) {
-            return EitherOf2.withB(nothing())
+            return noReaction().asB()
         }
         val minorUnits = currencyType.minorUnitField
         val otherValue = minorUnitsPerUnit(currencyType)

--- a/java-tests/extensions/src/main/kotlin/io/spine/validation/test/CurrencyValidationPolicy.kt
+++ b/java-tests/extensions/src/main/kotlin/io/spine/validation/test/CurrencyValidationPolicy.kt
@@ -31,14 +31,17 @@ import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.event.TypeExited
 import io.spine.protodata.plugin.Policy
 import io.spine.protodata.value.Value
+import io.spine.protodata.value.value
 import io.spine.server.event.NoReaction
 import io.spine.server.event.React
-import io.spine.server.event.asB
+import io.spine.server.event.asA
 import io.spine.server.query.select
 import io.spine.server.tuple.EitherOf2
 import io.spine.validation.ComparisonOperator.LESS_THAN
 import io.spine.validation.SimpleRule
 import io.spine.validation.event.SimpleRuleAdded
+import io.spine.validation.event.simpleRuleAdded
+import io.spine.validation.simpleRule
 import io.spine.validation.test.money.CurrencyType
 
 /**
@@ -53,35 +56,28 @@ public class CurrencyValidationPolicy : Policy<TypeExited>() {
     override fun whenever(@External event: TypeExited): EitherOf2<SimpleRuleAdded, NoReaction> {
         val currencyType = select<CurrencyType>().findById(event.type)
         if (currencyType == null || currencyType.hasCurrency().not()) {
-            return noReaction().asB()
+            return ignore()
         }
         val minorUnits = currencyType.minorUnitField
         val otherValue = minorUnitsPerUnit(currencyType)
         val rule = constructRule(currencyType.majorUnitField, minorUnits, otherValue)
-        return EitherOf2.withA(
-            SimpleRuleAdded.newBuilder()
-                .setType(event.type)
-                .setRule(rule)
-                .build()
-        )
+        return simpleRuleAdded {
+            type = event.type
+            this.rule = rule
+        }.asA()
     }
 
-    private fun minorUnitsPerUnit(currencyType: CurrencyType): Value {
-        return Value.newBuilder()
-            .setIntValue(currencyType.currency.minorUnits.toLong())
-            .build()
-    }
+    private fun minorUnitsPerUnit(currencyType: CurrencyType): Value =
+        value { intValue = currencyType.currency.minorUnits.toLong() }
 
-    private fun constructRule(majorUnits: Field, minorUnits: Field, otherValue: Value): SimpleRule {
-        val msg = "Expected less than {other} ${minorUnits.prettyName()} per one " +
-                "${majorUnits.prettyName()}, but got {value}."
-        return SimpleRule.newBuilder()
-            .setErrorMessage(msg)
-            .setField(minorUnits.name)
-            .setOperator(LESS_THAN)
-            .setOtherValue(otherValue)
-            .build()
-    }
+    private fun constructRule(majorUnits: Field, minorUnits: Field, otherValue: Value): SimpleRule =
+        simpleRule {
+            errorMessage = "Expected less than {other} ${minorUnits.prettyName()} per one " +
+                    "${majorUnits.prettyName()}, but got {value}."
+            field = minorUnits.name
+            operator = LESS_THAN
+            this.otherValue = otherValue
+        }
 }
 
 private fun Field.prettyName() = name.value.replaceFirstChar { it.uppercase() }

--- a/java-tests/extensions/src/main/kotlin/io/spine/validation/test/MoneyValidationPlugin.kt
+++ b/java-tests/extensions/src/main/kotlin/io/spine/validation/test/MoneyValidationPlugin.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -27,15 +27,9 @@
 package io.spine.validation.test
 
 import io.spine.protodata.plugin.Plugin
-import io.spine.protodata.plugin.Policy
-import io.spine.protodata.plugin.ViewRepository
 
 @Suppress("unused") // Accessed reflectively by ProtoData.
-public class MoneyValidationPlugin : Plugin {
-
-    override fun viewRepositories(): Set<ViewRepository<*, *, *>> =
-        setOf(CurrencyTypeView.Repo())
-
-    override fun policies(): Set<Policy<*>> =
-        setOf(CurrencyValidationPolicy())
-}
+public class MoneyValidationPlugin : Plugin(
+    viewRepositories = setOf(CurrencyTypeView.Repo()),
+    policies = setOf(CurrencyValidationPolicy())
+)

--- a/java/src/main/java/io/spine/validation/java/JavaValidationPlugin.java
+++ b/java/src/main/java/io/spine/validation/java/JavaValidationPlugin.java
@@ -28,15 +28,11 @@ package io.spine.validation.java;
 
 import com.google.common.collect.ImmutableList;
 import io.spine.protodata.plugin.Plugin;
-import io.spine.protodata.plugin.Policy;
-import io.spine.protodata.plugin.View;
-import io.spine.protodata.plugin.ViewRepository;
 import io.spine.protodata.render.Renderer;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.validation.ValidationPlugin;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -48,7 +44,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * extend this plugin's behavior and supply a more rich base plugin.
  */
 @SuppressWarnings("unused") // Accessed via reflection.
-public final class JavaValidationPlugin implements Plugin {
+public final class JavaValidationPlugin extends Plugin {
 
     private final Plugin base;
 
@@ -59,6 +55,12 @@ public final class JavaValidationPlugin implements Plugin {
      * @param base the base plugin to extend
      */
     public JavaValidationPlugin(Plugin base) {
+        super(
+            mergeRenderers(base),
+            base.getViews(),
+            base.getViewRepositories(),
+            base.getPolicies()
+        );
         this.base = checkNotNull(base);
     }
 
@@ -72,15 +74,12 @@ public final class JavaValidationPlugin implements Plugin {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>{@code JavaValidationPlugin} orders the renderers in such a way that the renderers of
+     * Orders the renderers in such a way that the renderers of
      * the {@code base} plugin always come before its own renderers.
      */
-    @Override
-    public List<Renderer<?>> renderers() {
+    private static List<Renderer<?>> mergeRenderers(Plugin base) {
         var result = ImmutableList.<Renderer<?>>builder();
-        result.addAll(base.renderers());
+        result.addAll(base.getRenderers());
         result.add(new PrintValidationInsertionPoints(),
                    new JavaValidationRenderer(),
                    new ImplementValidatingBuilder());
@@ -90,20 +89,5 @@ public final class JavaValidationPlugin implements Plugin {
     @Override
     public void extend(BoundedContextBuilder context) {
         base.extend(context);
-    }
-
-    @Override
-    public Set<Class<? extends View<?, ?, ?>>> views() {
-        return base.views();
-    }
-
-    @Override
-    public Set<Policy<?>> policies() {
-        return base.policies();
-    }
-
-    @Override
-    public Set<ViewRepository<?, ?, ?>> viewRepositories() {
-        return base.viewRepositories();
     }
 }

--- a/java/src/main/kotlin/io/spine/validation/java/RequiredOneofGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/RequiredOneofGenerator.kt
@@ -37,7 +37,7 @@ import io.spine.validation.ErrorMessage
  *
  * The constraint applies to a `oneof` group and enforces an alternative to be set.
  * The generated code checks that the `oneof`'s case is one of the alternatives,
- * i.e., not not-set.
+ * i.e., the `oneof` is initialized with an option.
  */
 internal class RequiredOneofGenerator(
     private val name: OneofName,

--- a/model/src/main/java/io/spine/validation/BoolFieldOptionRepo.java
+++ b/model/src/main/java/io/spine/validation/BoolFieldOptionRepo.java
@@ -44,8 +44,8 @@ abstract class BoolFieldOptionRepo<
         super.setupEventRouting(routing);
         routing.unicast(FieldOptionDiscovered.class,
                         (e, c) -> FieldId.newBuilder()
-                                .setType(e.getType())
-                                .setName(e.getField())
+                                .setType(e.getSubject().getDeclaringType())
+                                .setName(e.getSubject().getName())
                                 .build()
         );
     }

--- a/model/src/main/java/io/spine/validation/DistinctPolicy.java
+++ b/model/src/main/java/io/spine/validation/DistinctPolicy.java
@@ -31,10 +31,10 @@ import io.spine.core.External;
 import io.spine.core.Where;
 import io.spine.protodata.ast.FieldName;
 import io.spine.protodata.ast.File;
-import io.spine.protodata.ast.event.FieldOptionDiscovered;
 import io.spine.protodata.ast.TypeName;
+import io.spine.protodata.ast.event.FieldOptionDiscovered;
+import io.spine.server.event.NoReaction;
 import io.spine.server.event.React;
-import io.spine.server.model.Nothing;
 import io.spine.server.tuple.EitherOf2;
 import io.spine.validation.event.RuleAdded;
 import io.spine.validation.event.SimpleRuleAdded;
@@ -59,12 +59,12 @@ final class DistinctPolicy extends ValidationPolicy<FieldOptionDiscovered> {
 
     @Override
     @React
-    protected EitherOf2<RuleAdded, Nothing> whenever(
+    protected EitherOf2<RuleAdded, NoReaction> whenever(
             @External @Where(field = OPTION_NAME, equals = "distinct") FieldOptionDiscovered event
     ) {
         var option = event.getOption();
         if (!unpack(option.getValue(), BoolValue.class).getValue()) {
-            return noReaction();
+            return ignoring();
         }
         checkCollection(event.getField(), event.getType(), event.getFile());
         var field = event.getField();

--- a/model/src/main/java/io/spine/validation/DistinctPolicy.java
+++ b/model/src/main/java/io/spine/validation/DistinctPolicy.java
@@ -66,14 +66,16 @@ final class DistinctPolicy extends ValidationPolicy<FieldOptionDiscovered> {
         if (!unpack(option.getValue(), BoolValue.class).getValue()) {
             return ignoring();
         }
-        checkCollection(event.getField(), event.getType(), event.getFile());
-        var field = event.getField();
+        var field = event.getSubject();
+        var declaringType = field.getDeclaringType();
+        var fieldName = field.getName();
+        checkCollection(fieldName, declaringType, event.getFile());
         var rule = SimpleRules.withCustom(
-                field, DistinctCollection.getDefaultInstance(), ERROR, ERROR, false
+                fieldName, DistinctCollection.getDefaultInstance(), ERROR, ERROR, false
         );
         return EitherOf2.withA(
                 SimpleRuleAdded.newBuilder()
-                        .setType(event.getType())
+                        .setType(declaringType)
                         .setRule(rule)
                         .build()
         );
@@ -83,8 +85,8 @@ final class DistinctPolicy extends ValidationPolicy<FieldOptionDiscovered> {
         var field = findField(fieldName, typeName, file, this);
         if (!isRepeated(field)) {
             throw newIllegalStateException(
-                    "Field `%s.%s` is neither a `repeated` nor a `map` and " +
-                            "therefore cannot be `distinct`.",
+                    "The field `%s.%s` is neither a `repeated` nor a `map` and " +
+                            "therefore cannot be `(distinct)`.",
                     getQualifiedName(typeName),
                     fieldName.getValue());
         }

--- a/model/src/main/java/io/spine/validation/DistinctPolicy.java
+++ b/model/src/main/java/io/spine/validation/DistinctPolicy.java
@@ -64,7 +64,7 @@ final class DistinctPolicy extends ValidationPolicy<FieldOptionDiscovered> {
     ) {
         var option = event.getOption();
         if (!unpack(option.getValue(), BoolValue.class).getValue()) {
-            return ignoring();
+            return ignore();
         }
         var field = event.getSubject();
         var declaringType = field.getDeclaringType();

--- a/model/src/main/java/io/spine/validation/MaxPolicy.java
+++ b/model/src/main/java/io/spine/validation/MaxPolicy.java
@@ -29,8 +29,8 @@ package io.spine.validation;
 import io.spine.core.External;
 import io.spine.core.Where;
 import io.spine.protodata.ast.event.FieldOptionDiscovered;
-import io.spine.server.event.Just;
 import io.spine.protodata.plugin.Policy;
+import io.spine.server.event.Just;
 import io.spine.server.event.React;
 import io.spine.validation.event.SimpleRuleAdded;
 
@@ -50,10 +50,11 @@ final class MaxPolicy extends Policy<FieldOptionDiscovered> {
     ) {
         var option = event.getOption();
         var rules = NumberRules.from(option);
-        var rule = rules.maxRule(event.getField());
+        var field = event.getSubject();
+        var rule = rules.maxRule(field.getName());
         return just(
                 SimpleRuleAdded.newBuilder()
-                        .setType(event.getType())
+                        .setType(field.getDeclaringType())
                         .setRule(rule)
                         .build()
         );

--- a/model/src/main/java/io/spine/validation/MaxPolicy.java
+++ b/model/src/main/java/io/spine/validation/MaxPolicy.java
@@ -34,6 +34,7 @@ import io.spine.server.event.Just;
 import io.spine.server.event.React;
 import io.spine.validation.event.SimpleRuleAdded;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.event.Just.just;
 import static io.spine.validation.EventFieldNames.OPTION_NAME;
 
@@ -49,8 +50,9 @@ final class MaxPolicy extends Policy<FieldOptionDiscovered> {
             @External @Where(field = OPTION_NAME, equals = "max") FieldOptionDiscovered event
     ) {
         var option = event.getOption();
-        var rules = NumberRules.from(option);
         var field = event.getSubject();
+        var typeSystem = checkNotNull(getTypeSystem());
+        var rules = NumberRules.from(field, option, typeSystem);
         var rule = rules.maxRule(field.getName());
         return just(
                 SimpleRuleAdded.newBuilder()

--- a/model/src/main/java/io/spine/validation/MinPolicy.java
+++ b/model/src/main/java/io/spine/validation/MinPolicy.java
@@ -49,11 +49,12 @@ final class MinPolicy extends Policy<FieldOptionDiscovered> {
             @External @Where(field = OPTION_NAME, equals = "min") FieldOptionDiscovered event
     ) {
         var option = event.getOption();
+        var field = event.getSubject();
         var rules = NumberRules.from(option);
-        var rule = rules.minRule(event.getField());
+        var rule = rules.minRule(field.getName());
         return just(
                 SimpleRuleAdded.newBuilder()
-                        .setType(event.getType())
+                        .setType(field.getDeclaringType())
                         .setRule(rule)
                         .build()
         );

--- a/model/src/main/java/io/spine/validation/MinPolicy.java
+++ b/model/src/main/java/io/spine/validation/MinPolicy.java
@@ -34,6 +34,7 @@ import io.spine.server.event.Just;
 import io.spine.server.event.React;
 import io.spine.validation.event.SimpleRuleAdded;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.event.Just.just;
 import static io.spine.validation.EventFieldNames.OPTION_NAME;
 
@@ -50,7 +51,8 @@ final class MinPolicy extends Policy<FieldOptionDiscovered> {
     ) {
         var option = event.getOption();
         var field = event.getSubject();
-        var rules = NumberRules.from(option);
+        var typeSystem = checkNotNull(getTypeSystem());
+        var rules = NumberRules.from(field, option, typeSystem);
         var rule = rules.minRule(field.getName());
         return just(
                 SimpleRuleAdded.newBuilder()

--- a/model/src/main/java/io/spine/validation/PatternPolicy.java
+++ b/model/src/main/java/io/spine/validation/PatternPolicy.java
@@ -62,8 +62,9 @@ final class PatternPolicy extends Policy<FieldOptionDiscovered> {
         var error = customError.isEmpty()
                        ? Diags.Regex.errorMessage(regex)
                        : customError;
+        var field = event.getSubject();
         var rule = SimpleRules.withCustom(
-                event.getField(),
+                field.getName(),
                 feature,
                 "String should match regex.",
                 error,
@@ -71,7 +72,7 @@ final class PatternPolicy extends Policy<FieldOptionDiscovered> {
         );
         return just(
                 SimpleRuleAdded.newBuilder()
-                        .setType(event.getType())
+                        .setType(field.getDeclaringType())
                         .setRule(rule)
                         .build()
         );

--- a/model/src/main/java/io/spine/validation/RangePolicy.java
+++ b/model/src/main/java/io/spine/validation/RangePolicy.java
@@ -50,10 +50,11 @@ final class RangePolicy extends Policy<FieldOptionDiscovered> {
     ) {
         var option = event.getOption();
         var rules = NumberRules.from(option);
+        var field = event.getSubject();
         return just(
                 CompositeRuleAdded.newBuilder()
-                        .setType(event.getType())
-                        .setRule(rules.rangeRule(event.getField()))
+                        .setType(field.getDeclaringType())
+                        .setRule(rules.rangeRule(field.getName()))
                         .build()
         );
     }

--- a/model/src/main/java/io/spine/validation/RangePolicy.java
+++ b/model/src/main/java/io/spine/validation/RangePolicy.java
@@ -34,6 +34,7 @@ import io.spine.server.event.Just;
 import io.spine.server.event.React;
 import io.spine.validation.event.CompositeRuleAdded;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.event.Just.just;
 import static io.spine.validation.EventFieldNames.OPTION_NAME;
 
@@ -49,8 +50,9 @@ final class RangePolicy extends Policy<FieldOptionDiscovered> {
             @External @Where(field = OPTION_NAME, equals = "range") FieldOptionDiscovered event
     ) {
         var option = event.getOption();
-        var rules = NumberRules.from(option);
         var field = event.getSubject();
+        checkNotNull(getTypeSystem());
+        var rules = NumberRules.from(field, option, getTypeSystem());
         return just(
                 CompositeRuleAdded.newBuilder()
                         .setType(field.getDeclaringType())

--- a/model/src/main/java/io/spine/validation/RequiredPolicy.java
+++ b/model/src/main/java/io/spine/validation/RequiredPolicy.java
@@ -59,7 +59,7 @@ final class RequiredPolicy extends ValidationPolicy<FieldExited> {
             var declaration = findField(event.getField(), event.getType(), event.getFile(), this);
             return EitherOf2.withA(requiredRule(declaration, field));
         }
-        return ignoring();
+        return ignore();
     }
 
     private static RuleAdded requiredRule(Field declaration, RequiredField field) {

--- a/model/src/main/java/io/spine/validation/RequiredPolicy.java
+++ b/model/src/main/java/io/spine/validation/RequiredPolicy.java
@@ -30,8 +30,8 @@ import io.spine.core.External;
 import io.spine.protodata.ast.Field;
 import io.spine.protodata.ast.event.FieldExited;
 import io.spine.protodata.plugin.Policy;
+import io.spine.server.event.NoReaction;
 import io.spine.server.event.React;
-import io.spine.server.model.Nothing;
 import io.spine.server.tuple.EitherOf2;
 import io.spine.validation.event.RuleAdded;
 
@@ -49,7 +49,7 @@ final class RequiredPolicy extends ValidationPolicy<FieldExited> {
 
     @Override
     @React
-    protected EitherOf2<RuleAdded, Nothing> whenever(@External FieldExited event) {
+    protected EitherOf2<RuleAdded, NoReaction> whenever(@External FieldExited event) {
         var id = FieldId.newBuilder()
                 .setName(event.getField())
                 .setType(event.getType())
@@ -59,7 +59,7 @@ final class RequiredPolicy extends ValidationPolicy<FieldExited> {
             var declaration = findField(event.getField(), event.getType(), event.getFile(), this);
             return EitherOf2.withA(requiredRule(declaration, field));
         }
-        return noReaction();
+        return ignoring();
     }
 
     private static RuleAdded requiredRule(Field declaration, RequiredField field) {

--- a/model/src/main/java/io/spine/validation/ValidatePolicy.java
+++ b/model/src/main/java/io/spine/validation/ValidatePolicy.java
@@ -31,8 +31,8 @@ import io.spine.protodata.ast.FieldName;
 import io.spine.protodata.ast.File;
 import io.spine.protodata.ast.TypeName;
 import io.spine.protodata.ast.event.FieldExited;
+import io.spine.server.event.NoReaction;
 import io.spine.server.event.React;
-import io.spine.server.model.Nothing;
 import io.spine.server.tuple.EitherOf2;
 import io.spine.validation.event.RuleAdded;
 import io.spine.validation.event.SimpleRuleAdded;
@@ -55,7 +55,7 @@ final class ValidatePolicy extends ValidationPolicy<FieldExited> {
 
     @Override
     @React
-    protected EitherOf2<RuleAdded, Nothing> whenever(@External FieldExited event) {
+    protected EitherOf2<RuleAdded, NoReaction> whenever(@External FieldExited event) {
         var id = FieldId.newBuilder()
                 .setName(event.getField())
                 .setType(event.getType())
@@ -66,7 +66,7 @@ final class ValidatePolicy extends ValidationPolicy<FieldExited> {
         }
         var shouldValidate = field != null && field.getValidate();
         if (!shouldValidate) {
-            return noReaction();
+            return ignoring();
         }
         var rule = SimpleRules.withCustom(
                 event.getField(),

--- a/model/src/main/java/io/spine/validation/ValidatePolicy.java
+++ b/model/src/main/java/io/spine/validation/ValidatePolicy.java
@@ -66,7 +66,7 @@ final class ValidatePolicy extends ValidationPolicy<FieldExited> {
         }
         var shouldValidate = field != null && field.getValidate();
         if (!shouldValidate) {
-            return ignoring();
+            return ignore();
         }
         var rule = SimpleRules.withCustom(
                 event.getField(),

--- a/model/src/main/java/io/spine/validation/ValidationPlugin.java
+++ b/model/src/main/java/io/spine/validation/ValidationPlugin.java
@@ -26,42 +26,39 @@
 
 package io.spine.validation;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.spine.protodata.plugin.Plugin;
-import io.spine.protodata.plugin.Policy;
-import io.spine.protodata.plugin.ViewRepository;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A ProtoData plugin which attaches validation-related policies and views.
  */
 @SuppressWarnings("unused") // Loaded by ProtoData via reflection.
-public class ValidationPlugin implements Plugin {
+public class ValidationPlugin extends Plugin {
 
-    @SuppressWarnings("OverlyCoupledMethod") // Registers a lot of policies and does nothing else.
-    @Override
-    public ImmutableSet<Policy<?>> policies() {
-        return ImmutableSet.of(
-                new RequiredPolicy(),
-                new RangePolicy(),
-                new MinPolicy(),
-                new MaxPolicy(),
-                new DistinctPolicy(),
-                new ValidatePolicy(),
-                new PatternPolicy(),
-                new IsRequiredPolicy(),
-                new WhenPolicy(),
-                new RequiredIdPatternPolicy(),
-                new RequiredIdOptionPolicy()
-        );
-    }
-
-    @Override
-    public @NotNull ImmutableSet<ViewRepository<?, ?, ?>> viewRepositories() {
-        return ImmutableSet.of(
-                new MessageValidationRepository(),
-                new RequiredFieldRepository(),
-                new ValidatedFieldRepository()
+    @SuppressWarnings("OverlyCoupledMethod")
+    public ValidationPlugin() {
+        super(
+                ImmutableList.of() /* renderers */,
+                ImmutableSet.of() /* views */,
+                ImmutableSet.of(
+                        new MessageValidationRepository(),
+                        new RequiredFieldRepository(),
+                        new ValidatedFieldRepository()
+                ),
+                ImmutableSet.of(
+                        new RequiredPolicy(),
+                        new RangePolicy(),
+                        new MinPolicy(),
+                        new MaxPolicy(),
+                        new DistinctPolicy(),
+                        new ValidatePolicy(),
+                        new PatternPolicy(),
+                        new IsRequiredPolicy(),
+                        new WhenPolicy(),
+                        new RequiredIdPatternPolicy(),
+                        new RequiredIdOptionPolicy()
+                )
         );
     }
 }

--- a/model/src/main/java/io/spine/validation/ValidationPolicy.java
+++ b/model/src/main/java/io/spine/validation/ValidationPolicy.java
@@ -49,23 +49,4 @@ public abstract class ValidationPolicy<E extends EventMessage>
     @Override
     @ContractFor(handler = React.class)
     protected abstract EitherOf2<RuleAdded, NoReaction> whenever(E event);
-
-    /**
-     * Creates an {@link EitherOf2} with {@link NoReaction} in the {@code B} option.
-     *
-     * <p>Usage example:
-     * <pre>
-     *  {@literal class MyPolicy extends ValidationPolicy<TypeEntered>} {
-     *      {@literal @Override @React}
-     *      {@literal protected EitherOf2<RuleAdded, NoReaction> whenever}(TypeEntered event) {
-     *           if (!isRelevant(event)) {
-     *               return ignoring();
-     *           }
-     *           return myCustomRule(event);
-     *       }
-     * </pre>
-     */
-    protected final EitherOf2<RuleAdded, NoReaction> ignoring() {
-        return EitherOf2.withB(noReaction());
-    }
 }

--- a/model/src/main/java/io/spine/validation/ValidationPolicy.java
+++ b/model/src/main/java/io/spine/validation/ValidationPolicy.java
@@ -29,8 +29,8 @@ package io.spine.validation;
 import io.spine.base.EventMessage;
 import io.spine.core.ContractFor;
 import io.spine.protodata.plugin.Policy;
+import io.spine.server.event.NoReaction;
 import io.spine.server.event.React;
-import io.spine.server.model.Nothing;
 import io.spine.server.tuple.EitherOf2;
 import io.spine.validation.event.RuleAdded;
 
@@ -48,25 +48,24 @@ public abstract class ValidationPolicy<E extends EventMessage>
 
     @Override
     @ContractFor(handler = React.class)
-    protected abstract EitherOf2<RuleAdded, Nothing> whenever(E event);
+    protected abstract EitherOf2<RuleAdded, NoReaction> whenever(E event);
 
     /**
-     * Creates an {@link EitherOf2} with {@code Nothing} in the {@code B} option.
+     * Creates an {@link EitherOf2} with {@link NoReaction} in the {@code B} option.
      *
      * <p>Usage example:
      * <pre>
      *  {@literal class MyPolicy extends ValidationPolicy<TypeEntered>} {
      *      {@literal @Override @React}
-     *      {@literal protected EitherOf2<RuleAdded, Nothing> whenever}(TypeEntered event) {
+     *      {@literal protected EitherOf2<RuleAdded, NoReaction> whenever}(TypeEntered event) {
      *           if (!isRelevant(event)) {
-     *               return withNothing();
+     *               return ignoring();
      *           }
      *           return myCustomRule(event);
      *       }
      * </pre>
      */
-    protected final EitherOf2<RuleAdded, Nothing> noReaction() {
-        //TODO:2024-08-11:alexander.yevsyukov: Use EventProducer.noReaction() extension from `core-java`.
-        return EitherOf2.withB(nothing());
+    protected final EitherOf2<RuleAdded, NoReaction> ignoring() {
+        return EitherOf2.withB(noReaction());
     }
 }

--- a/model/src/main/java/io/spine/validation/WhenPolicy.java
+++ b/model/src/main/java/io/spine/validation/WhenPolicy.java
@@ -30,8 +30,8 @@ import io.spine.core.External;
 import io.spine.core.Where;
 import io.spine.protobuf.AnyPacker;
 import io.spine.protodata.ast.event.FieldOptionDiscovered;
-import io.spine.server.event.Just;
 import io.spine.protodata.plugin.Policy;
+import io.spine.server.event.Just;
 import io.spine.server.event.React;
 import io.spine.time.validation.TimeOption;
 import io.spine.validation.event.SimpleRuleAdded;
@@ -64,15 +64,16 @@ final class WhenPolicy extends Policy<FieldOptionDiscovered> {
                 .build();
         var errorMessage = format(
                 "The time must be in the %s.", time.name().toLowerCase(Locale.ENGLISH));
+        var field = event.getSubject();
         var rule = withCustom(
-                event.getField(),
+                field.getName(),
                 feature,
                 errorMessage,
                 errorMessage,
                 true);
         return just(
                 SimpleRuleAdded.newBuilder()
-                        .setType(event.getType())
+                        .setType(field.getDeclaringType())
                         .setRule(rule)
                         .build()
         );

--- a/model/src/main/java/io/spine/validation/package-info.java
+++ b/model/src/main/java/io/spine/validation/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -27,8 +27,8 @@
 /**
  * Contains the components for generating validation code.
  *
- * This package defines the validation model. Subpackages may contain language-specific codegen
- * implementation.
+ * <p>This package defines the validation model.
+ * Nested packages may contain language-specific codegen implementation.
  */
 @CheckReturnValue
 @ParametersAreNonnullByDefault

--- a/model/src/main/kotlin/io/spine/validation/IsRequiredPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/IsRequiredPolicy.kt
@@ -35,7 +35,7 @@ import io.spine.protodata.ast.event.OneofOptionDiscovered
 import io.spine.protodata.plugin.Policy
 import io.spine.server.event.NoReaction
 import io.spine.server.event.React
-import io.spine.server.event.asB
+import io.spine.server.event.asA
 import io.spine.server.tuple.EitherOf2
 import io.spine.validate.Diags.IsRequired.errorMessage
 import io.spine.validate.Diags.IsRequired.operatorDescription
@@ -59,7 +59,7 @@ internal class IsRequiredPolicy : Policy<OneofOptionDiscovered>() {
         // We have the option defined in the type. But is it set to `true`?
         val option = event.option.value.unpack<BoolValue>()
         if (!option.value) {
-            return noReaction().asB()
+            return ignore()
         }
         val requiredOneof = requiredOneof {
             name = event.group
@@ -72,9 +72,9 @@ internal class IsRequiredPolicy : Policy<OneofOptionDiscovered>() {
             errorMessage = errorMessage(event.group.value)
             operator = customOp
         }
-        return EitherOf2.withA(messageWideRuleAdded {
+        return messageWideRuleAdded {
             rule = messageWideRule
             type = event.type
-        })
+        }.asA()
     }
 }

--- a/model/src/main/kotlin/io/spine/validation/IsRequiredPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/IsRequiredPolicy.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+` * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -33,8 +33,9 @@ import io.spine.core.Where
 import io.spine.protobuf.pack
 import io.spine.protodata.ast.event.OneofOptionDiscovered
 import io.spine.protodata.plugin.Policy
+import io.spine.server.event.NoReaction
 import io.spine.server.event.React
-import io.spine.server.model.Nothing
+import io.spine.server.event.asB
 import io.spine.server.tuple.EitherOf2
 import io.spine.validate.Diags.IsRequired.errorMessage
 import io.spine.validate.Diags.IsRequired.operatorDescription
@@ -54,11 +55,11 @@ internal class IsRequiredPolicy : Policy<OneofOptionDiscovered>() {
     override fun whenever(
         @External @Where(field = OPTION_NAME, equals = "is_required")
         event: OneofOptionDiscovered
-    ): EitherOf2<MessageWideRuleAdded, Nothing> {
+    ): EitherOf2<MessageWideRuleAdded, NoReaction> {
         // We have the option defined in the type. But is it set to `true`?
         val option = event.option.value.unpack<BoolValue>()
         if (!option.value) {
-            return EitherOf2.withB(nothing())
+            return noReaction().asB()
         }
         val requiredOneof = requiredOneof {
             name = event.group

--- a/model/src/main/kotlin/io/spine/validation/NumberRules.kt
+++ b/model/src/main/kotlin/io/spine/validation/NumberRules.kt
@@ -38,13 +38,13 @@ import io.spine.protobuf.unpack
 import io.spine.protodata.ast.FieldName
 import io.spine.protodata.ast.Option
 import io.spine.protodata.value.Value
+import io.spine.protodata.value.Value.KindCase.DOUBLE_VALUE
+import io.spine.protodata.value.Value.KindCase.INT_VALUE
 import io.spine.validation.ComparisonOperator.GREATER_OR_EQUAL
 import io.spine.validation.ComparisonOperator.GREATER_THAN
 import io.spine.validation.ComparisonOperator.LESS_OR_EQUAL
 import io.spine.validation.ComparisonOperator.LESS_THAN
 import io.spine.validation.LogicalOperator.AND
-import io.spine.protodata.value.Value.KindCase.DOUBLE_VALUE
-import io.spine.protodata.value.Value.KindCase.INT_VALUE
 
 /**
  * A factory of validation rules for number fields.
@@ -153,7 +153,7 @@ private fun Option.toRules(): NumberRules = when {
         "Option $name is not a number range option."
     )
 }
-@Suppress("FunctionNaming") // backticked name is necessary here.
+
 private fun Option.isA(generated: GeneratedExtension<*, *>) =
     name == generated.descriptor.name && number == generated.number
 

--- a/model/src/main/kotlin/io/spine/validation/RangeNotation.kt
+++ b/model/src/main/kotlin/io/spine/validation/RangeNotation.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -27,10 +27,9 @@
 package io.spine.validation
 
 import com.google.common.collect.Range
-import io.spine.validate.ComparableNumber
 import io.spine.protodata.value.Value
+import io.spine.validate.ComparableNumber
 import java.util.regex.Pattern
-
 
 /**
  * Transforms a string value defined in a field declaration into a [Range] of [ComparableNumber]s.

--- a/model/src/main/kotlin/io/spine/validation/RequiredIdOptionPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/RequiredIdOptionPolicy.kt
@@ -28,10 +28,10 @@ package io.spine.validation
 
 import io.spine.core.External
 import io.spine.protodata.ast.MessageType
-import io.spine.protodata.ast.firstField
 import io.spine.protodata.ast.event.TypeDiscovered
+import io.spine.protodata.ast.firstField
+import io.spine.server.event.NoReaction
 import io.spine.server.event.React
-import io.spine.server.model.NoReaction
 import io.spine.server.tuple.EitherOf2
 import io.spine.validation.event.RuleAdded
 
@@ -57,11 +57,11 @@ internal class RequiredIdOptionPolicy : RequiredIdPolicy() {
     @Suppress("ReturnCount") // prefer sooner exit and precise conditions.
     override fun whenever(@External event: TypeDiscovered): EitherOf2<RuleAdded, NoReaction> {
         if (options.isEmpty()) {
-            return noReaction()
+            return ignoring()
         }
         val type = event.type
         if (!type.isEntityState()) {
-            return noReaction()
+            return ignoring()
         }
         val field = type.firstField
         return withField(field)

--- a/model/src/main/kotlin/io/spine/validation/RequiredIdOptionPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/RequiredIdOptionPolicy.kt
@@ -57,11 +57,11 @@ internal class RequiredIdOptionPolicy : RequiredIdPolicy() {
     @Suppress("ReturnCount") // prefer sooner exit and precise conditions.
     override fun whenever(@External event: TypeDiscovered): EitherOf2<RuleAdded, NoReaction> {
         if (options.isEmpty()) {
-            return ignoring()
+            return ignore()
         }
         val type = event.type
         if (!type.isEntityState()) {
-            return ignoring()
+            return ignore()
         }
         val field = type.firstField
         return withField(field)

--- a/model/src/main/kotlin/io/spine/validation/RequiredIdPatternPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/RequiredIdPatternPolicy.kt
@@ -35,8 +35,8 @@ import io.spine.protodata.ast.FilePattern
 import io.spine.protodata.ast.event.TypeDiscovered
 import io.spine.protodata.ast.firstField
 import io.spine.protodata.ast.matches
+import io.spine.server.event.NoReaction
 import io.spine.server.event.React
-import io.spine.server.model.NoReaction
 import io.spine.server.tuple.EitherOf2
 import io.spine.validation.event.RuleAdded
 
@@ -63,10 +63,10 @@ internal class RequiredIdPatternPolicy : RequiredIdPolicy() {
     @Suppress("ReturnCount") // prefer sooner exit and precise conditions.
     override fun whenever(@External event: TypeDiscovered): EitherOf2<RuleAdded, NoReaction> {
         if (filePatterns.isEmpty()) {
-            return noReaction()
+            return ignoring()
         }
         if (!event.file.matchesPatterns()) {
-            return noReaction()
+            return ignoring()
         }
         val type = event.type
         val field = type.firstField

--- a/model/src/main/kotlin/io/spine/validation/RequiredIdPatternPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/RequiredIdPatternPolicy.kt
@@ -63,10 +63,10 @@ internal class RequiredIdPatternPolicy : RequiredIdPolicy() {
     @Suppress("ReturnCount") // prefer sooner exit and precise conditions.
     override fun whenever(@External event: TypeDiscovered): EitherOf2<RuleAdded, NoReaction> {
         if (filePatterns.isEmpty()) {
-            return ignoring()
+            return ignore()
         }
         if (!event.file.matchesPatterns()) {
-            return ignoring()
+            return ignore()
         }
         val type = event.type
         val field = type.firstField

--- a/model/src/main/kotlin/io/spine/validation/RequiredIdPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/RequiredIdPolicy.kt
@@ -28,7 +28,7 @@ package io.spine.validation
 import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.event.TypeDiscovered
 import io.spine.protodata.settings.loadSettings
-import io.spine.server.model.NoReaction
+import io.spine.server.event.NoReaction
 import io.spine.server.tuple.EitherOf2
 import io.spine.validation.RequiredRule.isRequired
 import io.spine.validation.event.RuleAdded
@@ -65,12 +65,12 @@ internal abstract class RequiredIdPolicy : ValidationPolicy<TypeDiscovered>() {
     @Suppress("ReturnCount") // prefer sooner exit and precise conditions.
     fun withField(field: Field): EitherOf2<RuleAdded, NoReaction> {
         if (!isRequired(field, true)) {
-            return noReaction()
+            return ignoring()
         }
         val errorMessage = "ID field `${field.name.value}` must be set."
         val rule = RequiredRule.forField(field, errorMessage)
         if (rule.isEmpty) {
-            return noReaction()
+            return ignoring()
         }
         return EitherOf2.withA(rule.get().toEvent(field.declaringType))
     }

--- a/model/src/main/kotlin/io/spine/validation/RequiredIdPolicy.kt
+++ b/model/src/main/kotlin/io/spine/validation/RequiredIdPolicy.kt
@@ -29,6 +29,7 @@ import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.event.TypeDiscovered
 import io.spine.protodata.settings.loadSettings
 import io.spine.server.event.NoReaction
+import io.spine.server.event.asA
 import io.spine.server.tuple.EitherOf2
 import io.spine.validation.RequiredRule.isRequired
 import io.spine.validation.event.RuleAdded
@@ -65,13 +66,13 @@ internal abstract class RequiredIdPolicy : ValidationPolicy<TypeDiscovered>() {
     @Suppress("ReturnCount") // prefer sooner exit and precise conditions.
     fun withField(field: Field): EitherOf2<RuleAdded, NoReaction> {
         if (!isRequired(field, true)) {
-            return ignoring()
+            return ignore()
         }
         val errorMessage = "ID field `${field.name.value}` must be set."
         val rule = RequiredRule.forField(field, errorMessage)
         if (rule.isEmpty) {
-            return ignoring()
+            return ignore()
         }
-        return EitherOf2.withA(rule.get().toEvent(field.declaringType))
+        return rule.get().toEvent(field.declaringType).asA()
     }
 }

--- a/model/src/test/kotlin/io/spine/validation/PolicySpec.kt
+++ b/model/src/test/kotlin/io/spine/validation/PolicySpec.kt
@@ -50,6 +50,8 @@ import io.spine.protodata.ast.type
 import io.spine.protodata.ast.typeName
 import io.spine.protodata.backend.CodeGenerationContext
 import io.spine.protodata.backend.Pipeline
+import io.spine.protodata.plugin.applyTo
+import io.spine.protodata.type.TypeSystem
 import io.spine.testing.server.blackbox.BlackBox
 import io.spine.validation.ComparisonOperator.GREATER_OR_EQUAL
 import io.spine.validation.ComparisonOperator.LESS_OR_EQUAL
@@ -80,8 +82,11 @@ class PolicySpec {
 
     @BeforeEach
     fun prepareBlackBox() {
-        codegenContext = CodeGenerationContext(Pipeline.generateId()) {
-            ValidationPlugin().policies().forEach { addEventDispatcher(it) }
+        val typeSystem = TypeSystem(emptySet())
+        val plugin = ValidationPlugin()
+        codegenContext = CodeGenerationContext(Pipeline.generateId(), typeSystem) {
+            // Mimic what a `Pipeline` does to its plugins.
+            plugin.applyTo(this, typeSystem)
         }
 
         blackBox = BlackBox.from(codegenContext.context)
@@ -126,8 +131,6 @@ class PolicySpec {
 
         blackBox.receivesExternalEvent(
             fieldOptionDiscovered {
-                field = fieldName
-                type = typeName
                 file = this@PolicySpec.filePath
                 option = rangeOption
                 subject = field {

--- a/model/src/test/kotlin/io/spine/validation/PolicySpec.kt
+++ b/model/src/test/kotlin/io/spine/validation/PolicySpec.kt
@@ -36,8 +36,6 @@ import io.spine.protodata.ast.PrimitiveType.TYPE_INT32
 import io.spine.protodata.ast.PrimitiveType.TYPE_STRING
 import io.spine.protodata.ast.ProtoFileHeader.SyntaxVersion.PROTO3
 import io.spine.protodata.ast.Type
-import io.spine.protodata.backend.CodeGenerationContext
-import io.spine.protodata.backend.Pipeline
 import io.spine.protodata.ast.event.fieldEntered
 import io.spine.protodata.ast.event.fieldOptionDiscovered
 import io.spine.protodata.ast.event.fileEntered
@@ -50,6 +48,8 @@ import io.spine.protodata.ast.option
 import io.spine.protodata.ast.protoFileHeader
 import io.spine.protodata.ast.type
 import io.spine.protodata.ast.typeName
+import io.spine.protodata.backend.CodeGenerationContext
+import io.spine.protodata.backend.Pipeline
 import io.spine.testing.server.blackbox.BlackBox
 import io.spine.validation.ComparisonOperator.GREATER_OR_EQUAL
 import io.spine.validation.ComparisonOperator.LESS_OR_EQUAL
@@ -130,6 +130,12 @@ class PolicySpec {
                 type = typeName
                 file = this@PolicySpec.filePath
                 option = rangeOption
+                subject = field {
+                    declaringType = typeName
+                    name = fieldName
+                    type = primitive(TYPE_INT32)
+                    single = Empty.getDefaultInstance()
+                }
             }
         )
         blackBox.assertEvent(CompositeRuleAdded::class.java)

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.215</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -74,19 +74,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-api</artifactId>
-    <version>0.61.6</version>
+    <version>0.61.8</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-backend</artifactId>
-    <version>0.61.6</version>
+    <version>0.61.8</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-java</artifactId>
-    <version>0.61.6</version>
+    <version>0.61.8</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -233,12 +233,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.61.6</version>
+    <version>0.61.8</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.61.6</version>
+    <version>0.61.8</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,19 +74,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-api</artifactId>
-    <version>0.63.1</version>
+    <version>0.63.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-backend</artifactId>
-    <version>0.63.1</version>
+    <version>0.63.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-java</artifactId>
-    <version>0.63.1</version>
+    <version>0.63.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -233,12 +233,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.63.1</version>
+    <version>0.63.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.63.1</version>
+    <version>0.63.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.233</version>
+    <version>2.0.0-SNAPSHOT.240</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -74,19 +74,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-api</artifactId>
-    <version>0.61.8</version>
+    <version>0.63.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-backend</artifactId>
-    <version>0.61.8</version>
+    <version>0.63.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-java</artifactId>
-    <version>0.61.8</version>
+    <version>0.63.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.184</version>
+    <version>2.0.0-SNAPSHOT.185</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -233,12 +233,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.61.8</version>
+    <version>0.63.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.61.8</version>
+    <version>0.63.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -248,13 +248,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.244</version>
+    <version>2.0.0-SNAPSHOT.247</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.244</version>
+    <version>2.0.0-SNAPSHOT.247</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.176</version>
+    <version>2.0.0-SNAPSHOT.177</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -74,19 +74,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-api</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.6</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-backend</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.6</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-java</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.6</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -146,7 +146,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.176</version>
+    <version>2.0.0-SNAPSHOT.177</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -233,12 +233,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.6</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.61.4</version>
+    <version>0.61.6</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.161</version>
+<version>2.0.0-SNAPSHOT.162</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -248,18 +248,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.243</version>
+    <version>2.0.0-SNAPSHOT.244</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.243</version>
+    <version>2.0.0-SNAPSHOT.244</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.160</version>
+    <version>2.0.0-SNAPSHOT.161</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.161")
+val validationVersion by extra("2.0.0-SNAPSHOT.162")


### PR DESCRIPTION
This PR migrates Validation plugins to new `Plugin` API recently introduced in ProtoData.

Convenience extension functions `asA()` and `asB()` were also adopted.
