### PR TITLE
Bump ProtoData and McJava

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.259"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.262"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.259"
+    const val version = "2.0.0-SNAPSHOT.262"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.80.5"
+    private const val fallbackVersion = "0.90.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.80.5"
+    private const val fallbackDfVersion = "0.90.1"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/dependencies.md
+++ b/dependencies.md
@@ -848,7 +848,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:40 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1448,7 +1448,7 @@ This report was generated on **Tue Dec 24 20:20:40 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:40 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2110,7 +2110,7 @@ This report was generated on **Tue Dec 24 20:20:40 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:41 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3031,7 +3031,7 @@ This report was generated on **Tue Dec 24 20:20:41 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:43 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3895,7 +3895,7 @@ This report was generated on **Tue Dec 24 20:20:43 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:43 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4785,7 +4785,7 @@ This report was generated on **Tue Dec 24 20:20:43 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:44 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5657,7 +5657,7 @@ This report was generated on **Tue Dec 24 20:20:44 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:44 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6410,7 +6410,7 @@ This report was generated on **Tue Dec 24 20:20:44 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:45 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7308,7 +7308,7 @@ This report was generated on **Tue Dec 24 20:20:45 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:45 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8064,7 +8064,7 @@ This report was generated on **Tue Dec 24 20:20:45 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:46 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8824,7 +8824,7 @@ This report was generated on **Tue Dec 24 20:20:46 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:46 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9575,7 +9575,7 @@ This report was generated on **Tue Dec 24 20:20:46 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:47 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10449,7 +10449,7 @@ This report was generated on **Tue Dec 24 20:20:47 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:47 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11323,4 +11323,4 @@ This report was generated on **Tue Dec 24 20:20:47 CET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 24 20:20:48 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jan 04 17:50:11 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java-tests/consumer/build.gradle.kts
+++ b/java-tests/consumer/build.gradle.kts
@@ -26,9 +26,7 @@
 
 import io.spine.dependency.local.TestLib
 import io.spine.dependency.local.Time
-import io.spine.protodata.gradle.plugin.CreateSettingsDirectory
 import io.spine.protodata.gradle.plugin.LaunchProtoData
-import io.spine.util.theOnly
 
 protoData {
     plugins(
@@ -39,14 +37,11 @@ protoData {
     )
 }
 
-val settingsDirTask: CreateSettingsDirectory = tasks.withType<CreateSettingsDirectory>().theOnly()
-
 val copySettings by tasks.registering(Copy::class) {
     from(project.layout.projectDirectory.file(
         "io.spine.validation.java.JavaValidationPlugin.pb.json")
     )
-    into(settingsDirTask.settingsDir.get())
-    dependsOn(settingsDirTask)
+    into(project.layout.buildDirectory.dir("protodata/settings"))
 }
 
 tasks.withType<LaunchProtoData>().configureEach {

--- a/model/src/test/kotlin/io/spine/validation/PolicySpec.kt
+++ b/model/src/test/kotlin/io/spine/validation/PolicySpec.kt
@@ -51,6 +51,7 @@ import io.spine.protodata.ast.typeName
 import io.spine.protodata.backend.CodeGenerationContext
 import io.spine.protodata.backend.Pipeline
 import io.spine.protodata.plugin.applyTo
+import io.spine.protodata.protobuf.ProtoFileList
 import io.spine.protodata.type.TypeSystem
 import io.spine.testing.server.blackbox.BlackBox
 import io.spine.validation.ComparisonOperator.GREATER_OR_EQUAL
@@ -82,7 +83,10 @@ class PolicySpec {
 
     @BeforeEach
     fun prepareBlackBox() {
-        val typeSystem = TypeSystem(emptySet())
+        val typeSystem = TypeSystem(
+            ProtoFileList(emptyList()),
+            emptySet()
+        )
         val plugin = ValidationPlugin()
         codegenContext = CodeGenerationContext(Pipeline.generateId(), typeSystem) {
             // Mimic what a `Pipeline` does to its plugins.

--- a/model/src/test/kotlin/io/spine/validation/required/RequiredPolicySpec.kt
+++ b/model/src/test/kotlin/io/spine/validation/required/RequiredPolicySpec.kt
@@ -46,9 +46,9 @@ import org.junit.jupiter.api.io.TempDir
 internal class RequiredPolicySpec {
 
     @Test
-    fun `reject option on a boolean field`(@TempDir outputDir: Path, @TempDir settingsDir: Path) {
+    fun `reject option on a boolean field`(@TempDir workingDir: Path) {
         val message = WithBoolField.getDescriptor()
-        val error = compile(message, outputDir, settingsDir)
+        val error = compile(message, workingDir)
 
         val field = message.field("really")
         val expected = fieldDoesNotSupportRequired(field)
@@ -56,9 +56,9 @@ internal class RequiredPolicySpec {
     }
 
     @Test
-    fun `reject option on an integer field`(@TempDir outputDir: Path, @TempDir settingsDir: Path) {
+    fun `reject option on an integer field`(@TempDir workingDir: Path) {
         val message = WithIntField.getDescriptor()
-        val error = compile(message, outputDir, settingsDir)
+        val error = compile(message, workingDir)
 
         val field = message.field("zero")
         val expected = fieldDoesNotSupportRequired(field)
@@ -66,12 +66,9 @@ internal class RequiredPolicySpec {
     }
 
     @Test
-    fun `reject option on a signed integer field`(
-        @TempDir outputDir: Path,
-        @TempDir settingsDir: Path
-    ) {
+    fun `reject option on a signed integer field`(@TempDir workingDir: Path) {
         val message = WithSignedInt.getDescriptor()
-        val error = compile(message, outputDir, settingsDir)
+        val error = compile(message, workingDir)
 
         val field = message.field("signed")
         val expected = fieldDoesNotSupportRequired(field)
@@ -79,12 +76,9 @@ internal class RequiredPolicySpec {
     }
 
     @Test
-    fun `reject option on a double field`(
-        @TempDir outputDir: Path,
-        @TempDir settingsDir: Path
-    ) {
+    fun `reject option on a double field`(@TempDir workingDir: Path) {
         val message = WithDoubleField.getDescriptor()
-        val error = compile(message, outputDir, settingsDir)
+        val error = compile(message, workingDir)
 
         val field = message.field("temperature")
         val expected = fieldDoesNotSupportRequired(field)
@@ -96,10 +90,9 @@ internal class RequiredPolicySpec {
      */
     private fun compile(
         descriptor: Descriptor,
-        outputDir: Path,
-        settingsDir: Path
+        workingDir: Path
     ): Compilation.Error {
-        val fixture = ValidationTestFixture(descriptor, outputDir, settingsDir)
+        val fixture = ValidationTestFixture(descriptor, workingDir)
         val pipeline = fixture.setup.createPipeline()
         val error = assertThrows<Compilation.Error> {
             // Redirect console output so that we don't print errors during the build.

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-backend</artifactId>
-    <version>0.80.5</version>
+    <version>0.90.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-java</artifactId>
-    <version>0.80.5</version>
+    <version>0.90.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -134,13 +134,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-api</artifactId>
-    <version>0.80.5</version>
+    <version>0.90.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-testlib</artifactId>
-    <version>0.80.5</version>
+    <version>0.90.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -239,12 +239,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.80.5</version>
+    <version>0.90.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.80.5</version>
+    <version>0.90.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -259,18 +259,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.259</version>
+    <version>2.0.0-SNAPSHOT.262</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.259</version>
+    <version>2.0.0-SNAPSHOT.262</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.177</version>
+    <version>2.0.0-SNAPSHOT.182</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
This PR updates the dependencies on ProtoData and McJava, addressing API changes introduced by latest versions of ProtoData.
