### PR TITLE
Fix escaping slash char

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -835,12 +835,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:05 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:27 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
@@ -1422,12 +1422,12 @@ This report was generated on **Tue Mar 04 16:32:05 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:06 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:27 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2084,12 +2084,12 @@ This report was generated on **Tue Mar 04 16:32:06 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:06 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3009,12 +3009,12 @@ This report was generated on **Tue Mar 04 16:32:06 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:06 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3873,12 +3873,12 @@ This report was generated on **Tue Mar 04 16:32:06 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4750,12 +4750,12 @@ This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5622,12 +5622,12 @@ This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer-dependency:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-consumer-dependency:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6362,12 +6362,12 @@ This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7251,12 +7251,12 @@ This report was generated on **Tue Mar 04 16:32:07 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8007,12 +8007,12 @@ This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-validating:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-validating:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8767,12 +8767,12 @@ This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:30 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9518,12 +9518,12 @@ This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:30 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10379,12 +10379,12 @@ This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:30 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.197`
+# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.198`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11240,4 +11240,4 @@ This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 04 16:32:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 05 12:53:30 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java-tests/runtime/src/test/kotlin/io/spine/validate/option/PatternSpec.kt
+++ b/java-tests/runtime/src/test/kotlin/io/spine/validate/option/PatternSpec.kt
@@ -125,6 +125,25 @@ internal class PatternSpec : ValidationOfConstraintTest() {
             .buildPartial()
         assertValid(message)
     }
+
+    @Test
+    fun `validate with forward and backward slashes`() {
+        assertValid(
+            AllThePatterns.newBuilder()
+                .setWithoutSlash("abc")
+                .buildPartial()
+        )
+        assertNotValid(
+            AllThePatterns.newBuilder()
+                .setWithoutSlash("ab/c")
+                .buildPartial()
+        )
+        assertNotValid(
+            AllThePatterns.newBuilder()
+                .setWithoutSlash("ab\\c")
+                .buildPartial()
+        )
+    }
 }
 
 private fun patternStringFor(email: String): @NonValidated PatternStringFieldValue =

--- a/java-tests/runtime/src/test/proto/spine/test/validation/patterns.proto
+++ b/java-tests/runtime/src/test/proto/spine/test/validation/patterns.proto
@@ -60,4 +60,6 @@ message AllThePatterns {
              (pattern).regex = ".*",
              (pattern).modifier.dot_all = true
     ];
+
+    string without_slash = 6 [(pattern).regex = "^[^\\\\/]*$"];
 }

--- a/java-tests/validating/src/testFixtures/proto/spine/test/validate/patterns.proto
+++ b/java-tests/validating/src/testFixtures/proto/spine/test/validate/patterns.proto
@@ -60,4 +60,22 @@ message AllThePatterns {
         (pattern).regex = ".*",
         (pattern).modifier.dot_all = true
     ];
+
+    // The `regex` option currently used in `TypeName` in ProtoData.
+    //
+    // The current value is accepted by Protobuf without escaping the slash character.
+    // Single backslash before the slash character is not accepted by Protobuf compiler.
+    //
+    string current_type_url_prefix = 6 [(pattern).regex = "^.*[^/]$"];
+
+    // The regex we are going to use for `TypeName` in ProtoData.
+    //
+    // This uses double backslash as it should be accepted in Java, and
+    // it is accepted by Protobuf too.
+    //
+    // The current problem with both last `regex` values that they are unnecessary
+    // escaped with yet another backslash character which causes error when Java compiles
+    // the generated code.
+    //
+    string new_type_url_prefix = 7 [(pattern).regex = "^(.*[^\\/])?$"];
 }

--- a/java-tests/validating/src/testFixtures/proto/spine/test/validate/patterns.proto
+++ b/java-tests/validating/src/testFixtures/proto/spine/test/validate/patterns.proto
@@ -60,22 +60,4 @@ message AllThePatterns {
         (pattern).regex = ".*",
         (pattern).modifier.dot_all = true
     ];
-
-    // The `regex` option currently used in `TypeName` in ProtoData.
-    //
-    // The current value is accepted by Protobuf without escaping the slash character.
-    // Single backslash before the slash character is not accepted by Protobuf compiler.
-    //
-    string current_type_url_prefix = 6 [(pattern).regex = "^.*[^/]$"];
-
-    // The regex we are going to use for `TypeName` in ProtoData.
-    //
-    // This uses double backslash as it should be accepted in Java, and
-    // it is accepted by Protobuf too.
-    //
-    // The current problem with both last `regex` values that they are unnecessary
-    // escaped with yet another backslash character which causes error when Java compiles
-    // the generated code.
-    //
-    string new_type_url_prefix = 7 [(pattern).regex = "^(.*[^\\/])?$"];
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.197</version>
+<version>2.0.0-SNAPSHOT.198</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.dependency.local.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.197")
+val validationVersion by extra("2.0.0-SNAPSHOT.198")


### PR DESCRIPTION
@yevhenii-nadtochii, I've created this PR to show the escaping issue we have with the `/` character in ProtoData. Please see `patterns.proto` with two new entries for the docs on what goes wrong.

I've experienced the issue when trying to build new ProtoData with new Validation. Please pick up this PR and fix the escaping.

If possible, please avoid using `org.apache.commons.lang` or other transitive utilities that may come via PSI to us. If you need escaping please use it from Guava on which we standardise. Or, which is more preferable, please find a Kotlin utility which does the same.

We should generally avoid having direct a dependency on Apache Commons or similar projects from Apache.
