### PR TITLE
Employ `restoreProtobufEscapes()` for Regex escaping

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -861,12 +861,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:47 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
@@ -1474,12 +1474,12 @@ This report was generated on **Thu Mar 06 17:29:47 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:48 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2162,12 +2162,12 @@ This report was generated on **Thu Mar 06 17:29:48 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:48 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:56 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3129,12 +3129,12 @@ This report was generated on **Thu Mar 06 17:29:48 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:48 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4019,12 +4019,12 @@ This report was generated on **Thu Mar 06 17:29:48 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4922,12 +4922,12 @@ This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:57 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5820,12 +5820,12 @@ This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer-dependency:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-consumer-dependency:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6586,12 +6586,12 @@ This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7517,12 +7517,12 @@ This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8299,12 +8299,12 @@ This report was generated on **Thu Mar 06 17:29:49 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-validating:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-validating:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9085,12 +9085,12 @@ This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:58 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9862,12 +9862,12 @@ This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10749,12 +10749,12 @@ This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11636,4 +11636,4 @@ This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 17:29:50 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 17:46:59 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java-tests/runtime/src/test/kotlin/io/spine/validate/option/PatternSpec.kt
+++ b/java-tests/runtime/src/test/kotlin/io/spine/validate/option/PatternSpec.kt
@@ -125,6 +125,25 @@ internal class PatternSpec : ValidationOfConstraintTest() {
             .buildPartial()
         assertValid(message)
     }
+
+    @Test
+    fun `validate with forward and backward slashes`() {
+        assertValid(
+            AllThePatterns.newBuilder()
+                .setWithoutSlash("abc")
+                .buildPartial()
+        )
+        assertNotValid(
+            AllThePatterns.newBuilder()
+                .setWithoutSlash("ab/c")
+                .buildPartial()
+        )
+        assertNotValid(
+            AllThePatterns.newBuilder()
+                .setWithoutSlash("ab\\c")
+                .buildPartial()
+        )
+    }
 }
 
 private fun patternStringFor(email: String): @NonValidated PatternStringFieldValue =

--- a/java-tests/runtime/src/test/proto/spine/test/validation/patterns.proto
+++ b/java-tests/runtime/src/test/proto/spine/test/validation/patterns.proto
@@ -60,4 +60,6 @@ message AllThePatterns {
              (pattern).regex = ".*",
              (pattern).modifier.dot_all = true
     ];
+
+    string without_slash = 6 [(pattern).regex = "^[^\\\\/]*$"];
 }

--- a/java/src/main/kotlin/io/spine/validation/java/generate/option/PatternFieldGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/generate/option/PatternFieldGenerator.kt
@@ -28,6 +28,7 @@ package io.spine.validation.java.generate.option
 
 import io.spine.base.FieldPath
 import io.spine.option.PatternOption
+import io.spine.protobuf.restoreProtobufEscapes
 import io.spine.protodata.ast.camelCase
 import io.spine.protodata.ast.name
 import io.spine.protodata.ast.qualifiedName
@@ -70,7 +71,6 @@ import io.spine.validation.java.generate.mangled
 import io.spine.validation.java.violation.templateString
 import java.util.regex.Matcher
 import java.util.regex.Pattern
-import org.apache.commons.lang.StringEscapeUtils.escapeJava
 
 /**
  * Stores the generated Java field that contains the compiled [Pattern]
@@ -184,7 +184,7 @@ internal class PatternFieldGenerator(private val view: PatternField) : FieldOpti
     private fun compilePattern(): CompiledPattern {
         val modifiers = view.modifier
         val compilationArgs = listOf(
-            StringLiteral(escapeJava(view.pattern)),
+            StringLiteral(restoreProtobufEscapes(view.pattern)),
             Literal(modifiers.asFlagsMask())
         )
         val field = FieldDeclaration<Pattern>(
@@ -224,8 +224,8 @@ internal class PatternFieldGenerator(private val view: PatternField) : FieldOpti
         FIELD_VALUE to fieldValue,
         FIELD_TYPE to StringLiteral(fieldType.name),
         PARENT_TYPE to StringLiteral(declaringType.qualifiedName),
-        REGEX_PATTERN to StringLiteral(escapeJava(view.pattern)),
-        REGEX_MODIFIERS to StringLiteral(escapeJava("${view.modifier}")),
+        REGEX_PATTERN to StringLiteral(restoreProtobufEscapes(view.pattern)),
+        REGEX_MODIFIERS to StringLiteral(restoreProtobufEscapes("${view.modifier}")),
     )
 }
 

--- a/java/src/main/kotlin/io/spine/validation/java/generate/option/PatternFieldGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/generate/option/PatternFieldGenerator.kt
@@ -180,6 +180,10 @@ internal class PatternFieldGenerator(private val view: PatternField) : FieldOpti
      * everything we need to yield an expression for [Pattern.matcher] invocation
      * under a single object. Otherwise, the [matches] method would have to accept
      * `partialMatch` parameter along with the string value to check.
+     *
+     * Note that [PatternField.pattern_] string should not contain unprintable
+     * characters to be used as a string literal. We have to [restore][restoreProtobufEscapes]
+     * escape sequences for them, if any.
      */
     private fun compilePattern(): CompiledPattern {
         val modifiers = view.modifier

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.300</version>
+<version>2.0.0-SNAPSHOT.301</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.dependency.local.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.300")
+val validationVersion by extra("2.0.0-SNAPSHOT.301")


### PR DESCRIPTION
This PR fixes slash escaping problem described in #195 by employing the `restoreProtobufEscapes()` method recently added to `base`.

Now, `PatternFieldGenerator` restores escape sequences that Protobuf compiler substituted with ASCII control characters.

Note that this changeset depends on #196.