### PR TITLE
Propagate `@Nullable` annotation to the generated code and add a precondition check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ allprojects {
                 Roaster.api,
                 Roaster.jdt,
                 ProtoData.api,
+                ProtoData.params,
                 ProtoData.pluginLib,
                 ProtoData.backend,
                 ProtoData.java,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.93.4"
+    private const val fallbackVersion = "0.93.5"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-java:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -861,12 +861,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:11 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:52 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-java-bundle:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.0.2.
@@ -1466,12 +1466,12 @@ This report was generated on **Mon Mar 24 18:47:11 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:11 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:52 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-java-runtime:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2154,12 +2154,12 @@ This report was generated on **Mon Mar 24 18:47:11 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:11 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-java-tests:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3128,12 +3128,12 @@ This report was generated on **Mon Mar 24 18:47:11 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-model:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4018,12 +4018,12 @@ This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-proto:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4972,12 +4972,12 @@ This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-consumer:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -5862,12 +5862,12 @@ This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-consumer-dependency:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-consumer-dependency:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6679,12 +6679,12 @@ This report was generated on **Mon Mar 24 18:47:12 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-extensions:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -7617,12 +7617,12 @@ This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-runtime:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8450,12 +8450,12 @@ This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-validating:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-validating:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9287,12 +9287,12 @@ This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-vanilla:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10056,12 +10056,12 @@ This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-configuration:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -10994,12 +10994,12 @@ This report was generated on **Mon Mar 24 18:47:13 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:14 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine.validation:spine-validation-context:2.0.0-SNAPSHOT.305`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11932,4 +11932,4 @@ This report was generated on **Mon Mar 24 18:47:14 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 24 18:47:14 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 11:24:55 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/java-tests/validating/src/test/kotlin/io/spine/test/JavaMessageSmokeTest.kt
+++ b/java-tests/validating/src/test/kotlin/io/spine/test/JavaMessageSmokeTest.kt
@@ -30,6 +30,7 @@ import com.google.protobuf.Message
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldNotBe
+import io.spine.base.FieldPath
 import io.spine.test.protobuf.CardNumber
 import io.spine.type.TypeName
 import io.spine.validate.NonValidated
@@ -77,7 +78,9 @@ internal class JavaMessageSmokeTest {
     fun `throw 'NullPointerException' if given 'null' for the parent path`() {
         val message = valid.build()
         assertThrows<NullPointerException> {
-            message.validate(null, TypeName.of("Something"))
+            // The cast prevents the Kotlin compiler warning about passing `null`
+            // to a non-`@Nullable` Java parameter.
+            message.validate(null as FieldPath, TypeName.of("Something"))
         }
     }
 

--- a/java-tests/validating/src/test/kotlin/io/spine/test/JavaMessageSmokeTest.kt
+++ b/java-tests/validating/src/test/kotlin/io/spine/test/JavaMessageSmokeTest.kt
@@ -73,6 +73,14 @@ internal class JavaMessageSmokeTest {
     }
 
     @Test
+    fun `throw 'NullPointerException' if given 'null' for the parent path`() {
+        val message = valid.build()
+        assertThrows<NullPointerException> {
+            message.validate(null, null)
+        }
+    }
+
+    @Test
     fun `ignore invalid message when skipping validation intentionally via 'buildPartial'`() {
         val number: @NonValidated Message = invalid.buildPartial()
         number shouldNotBe null

--- a/java-tests/validating/src/test/kotlin/io/spine/test/JavaMessageSmokeTest.kt
+++ b/java-tests/validating/src/test/kotlin/io/spine/test/JavaMessageSmokeTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldNotBe
 import io.spine.test.protobuf.CardNumber
+import io.spine.type.TypeName
 import io.spine.validate.NonValidated
 import io.spine.validate.ValidatableMessage
 import io.spine.validate.Validate.check
@@ -76,7 +77,7 @@ internal class JavaMessageSmokeTest {
     fun `throw 'NullPointerException' if given 'null' for the parent path`() {
         val message = valid.build()
         assertThrows<NullPointerException> {
-            message.validate(null, null)
+            message.validate(null, TypeName.of("Something"))
         }
     }
 

--- a/java/src/main/kotlin/io/spine/validation/java/expression/AnnotatedClassNames.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/expression/AnnotatedClassNames.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.validation.java.expression
+
+import io.spine.protodata.java.AnnotatedClassName
+import io.spine.protodata.java.ClassName
+import org.checkerframework.checker.nullness.qual.Nullable
+
+/**
+ * The [ClassName] of [org.checkerframework.checker.nullness.qual.Nullable].
+ */
+internal val NullableAnnotation = ClassName(Nullable::class)
+
+/**
+ * The [TypeNameClass] annotated with [NullableAnnotation].
+ */
+internal val NullableTypeNameClass = AnnotatedClassName(TypeNameClass, NullableAnnotation)

--- a/java/src/main/kotlin/io/spine/validation/java/expression/ClassNames.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/expression/ClassNames.kt
@@ -44,6 +44,7 @@ import io.spine.validate.ConstraintViolation
 import io.spine.validate.TemplateString
 import io.spine.validate.ValidatableMessage
 import io.spine.validate.ValidationError
+import java.util.*
 import java.util.regex.Pattern
 import java.util.stream.Collectors
 
@@ -155,3 +156,8 @@ internal val IntegerClassName = ClassName(Integer::class)
  * The [ClassName] of [java.lang.Long].
  */
 internal val LongClassName = ClassName(java.lang.Long::class)
+
+/**
+ * The [ClassName] of [java.util.Objects].
+ */
+internal val ObjectsClassName = ClassName(Objects::class)

--- a/java/src/main/kotlin/io/spine/validation/java/expression/ClassNames.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/expression/ClassNames.kt
@@ -150,14 +150,14 @@ internal val TypeNameClass = ClassName(TypeName::class)
 /**
  * The [ClassName] of [java.lang.Integer].
  */
-internal val IntegerClassName = ClassName(Integer::class)
+internal val IntegerClass = ClassName(Integer::class)
 
 /**
  * The [ClassName] of [java.lang.Long].
  */
-internal val LongClassName = ClassName(java.lang.Long::class)
+internal val LongClass = ClassName(java.lang.Long::class)
 
 /**
  * The [ClassName] of [java.util.Objects].
  */
-internal val ObjectsClassName = ClassName(Objects::class)
+internal val ObjectsClass = ClassName(Objects::class)

--- a/java/src/main/kotlin/io/spine/validation/java/generate/ValidationCodeInjector.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/generate/ValidationCodeInjector.kt
@@ -54,7 +54,10 @@ import io.spine.validate.Validated
 import io.spine.validate.ValidatingBuilder
 import io.spine.validation.java.generate.ValidationCodeInjector.ValidateScope.violations
 import io.spine.validation.java.expression.FieldPathClass
+import io.spine.validation.java.expression.ObjectsClassName
 import io.spine.validation.java.expression.TypeNameClass
+import io.spine.validation.java.generate.ValidationCodeInjector.ValidateScope.parentName
+import io.spine.validation.java.generate.ValidationCodeInjector.ValidateScope.parentPath
 
 /**
  * A [PsiClass] holding an instance of [Message].
@@ -168,7 +171,8 @@ private fun MessagePsiClass.declareDefaultValidateMethod() {
 private fun MessagePsiClass.declareValidateMethod(constraints: List<CodeBlock>) {
     val psiMethod = elementFactory.createMethodFromText(
         """
-        public java.util.Optional<io.spine.validate.ValidationError> validate($FieldPathClass parentPath, $TypeNameClass parentName) {
+        public java.util.Optional<io.spine.validate.ValidationError> validate($FieldPathClass $parentPath, $TypeNameClass $parentName) {
+            ${ObjectsClassName}.requireNonNull($parentPath);
             ${validateMethodBody(constraints)}
         }
         """.trimIndent(), this

--- a/java/src/main/kotlin/io/spine/validation/java/generate/ValidationCodeInjector.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/generate/ValidationCodeInjector.kt
@@ -54,8 +54,8 @@ import io.spine.validate.Validated
 import io.spine.validate.ValidatingBuilder
 import io.spine.validation.java.generate.ValidationCodeInjector.ValidateScope.violations
 import io.spine.validation.java.expression.FieldPathClass
-import io.spine.validation.java.expression.ObjectsClassName
-import io.spine.validation.java.expression.TypeNameClass
+import io.spine.validation.java.expression.NullableTypeNameClass
+import io.spine.validation.java.expression.ObjectsClass
 import io.spine.validation.java.generate.ValidationCodeInjector.ValidateScope.parentName
 import io.spine.validation.java.generate.ValidationCodeInjector.ValidateScope.parentPath
 
@@ -171,8 +171,8 @@ private fun MessagePsiClass.declareDefaultValidateMethod() {
 private fun MessagePsiClass.declareValidateMethod(constraints: List<CodeBlock>) {
     val psiMethod = elementFactory.createMethodFromText(
         """
-        public java.util.Optional<io.spine.validate.ValidationError> validate($FieldPathClass $parentPath, $TypeNameClass $parentName) {
-            ${ObjectsClassName}.requireNonNull($parentPath);
+        public java.util.Optional<io.spine.validate.ValidationError> validate($FieldPathClass $parentPath, $NullableTypeNameClass $parentName) {
+            ${ObjectsClass}.requireNonNull($parentPath);
             ${validateMethodBody(constraints)}
         }
         """.trimIndent(), this

--- a/java/src/main/kotlin/io/spine/validation/java/generate/option/RangeFieldGenerator.kt
+++ b/java/src/main/kotlin/io/spine/validation/java/generate/option/RangeFieldGenerator.kt
@@ -49,8 +49,8 @@ import io.spine.validation.NumericBound.ValueCase.UINT32_VALUE
 import io.spine.validation.NumericBound.ValueCase.UINT64_VALUE
 import io.spine.validation.RANGE
 import io.spine.validation.RangeField
-import io.spine.validation.java.expression.IntegerClassName
-import io.spine.validation.java.expression.LongClassName
+import io.spine.validation.java.expression.IntegerClass
+import io.spine.validation.java.expression.LongClass
 import io.spine.validation.java.expression.joinToString
 import io.spine.validation.java.expression.orElse
 import io.spine.validation.java.expression.resolve
@@ -133,10 +133,11 @@ internal class RangeFieldGenerator(private val view: RangeField) : FieldOptionGe
      * Returns a boolean expression that checks if the given [value] is within
      * the [lower] and [upper] bounds.
      *
-     * Unsigned values are handled in a special way because Java does not support them natively.
-     * [IntegerClassName] and [LongClassName] classes provide static methods to treat signed
-     * types as unsigned, including parsing, printing, comparison and math operations.
-     * Outside of these methods, these primitives remain just signed types.
+     * Unsigned values are handled in a special way because Java does not support
+     * them natively. [IntegerClass] and [LongClass] classes provide static methods
+     * to treat signed types as unsigned, including parsing, printing, comparison
+     * and math operations. Outside of these methods, these primitives remain just
+     * signed types.
      */
     private fun doesNotBelongToRange(value: Expression<Number>): Expression<Boolean>  {
         val valueCase = lower.valueCase // This case is the same for both `lower` and `upper`.
@@ -149,19 +150,19 @@ internal class RangeFieldGenerator(private val view: RangeField) : FieldOptionGe
                 "Unsigned integer types are not supported in Java. The Protobuf compiler uses" +
                         " signed integers to represent unsigned types in Java ($SCALAR_TYPES)." +
                         " Operations on unsigned values rely on static utility methods from" +
-                        " `$IntegerClassName` and `$LongClassName` classes ($UNSIGNED_API)." +
-                        " Be cautious when dealing with unsigned values outside of these methods," +
-                        " as Java treats all primitive integers as signed."
+                        " `$IntegerClass` and `$LongClass` classes ($UNSIGNED_API). Be cautious" +
+                        " when dealing with unsigned values outside of these methods, as Java" +
+                        " treats all primitive integers as signed."
             }
         }
         return when (valueCase) {
             UINT32_VALUE -> Expression(
-                "$IntegerClassName.compareUnsigned($value, $lowerLiteral) $lowerOperator 0 ||" +
-                        "$IntegerClassName.compareUnsigned($value, $upperLiteral) $upperOperator 0"
+                "$IntegerClass.compareUnsigned($value, $lowerLiteral) $lowerOperator 0 ||" +
+                        "$IntegerClass.compareUnsigned($value, $upperLiteral) $upperOperator 0"
             )
             UINT64_VALUE -> Expression(
-                "$LongClassName.compareUnsigned($value, $lowerLiteral) $lowerOperator 0 ||" +
-                        "$LongClassName.compareUnsigned($value, $upperLiteral) $upperOperator 0"
+                "$LongClass.compareUnsigned($value, $lowerLiteral) $lowerOperator 0 ||" +
+                        "$LongClass.compareUnsigned($value, $upperLiteral) $upperOperator 0"
             )
             else -> Expression(
                 "$value $lowerOperator $lowerLiteral ||" +
@@ -200,8 +201,8 @@ internal class RangeFieldGenerator(private val view: RangeField) : FieldOptionGe
  *
  * Note that `int` and `long` values that represent unsigned primitives are printed as is.
  * In the rendered Java code, they can become negative number constants due to overflow,
- * which is expected. [IntegerClassName] and [LongClassName] classes provide static methods
- * to treat signed primitives as unsigned.
+ * which is expected. [IntegerClass] and [LongClass] classes provide static methods to treat
+ * signed primitives as unsigned.
  */
 private fun NumericBound.asLiteral() =
     when (valueCase) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.validation</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.303</version>
+<version>2.0.0-SNAPSHOT.305</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -74,13 +74,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-backend</artifactId>
-    <version>0.93.4</version>
+    <version>0.93.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-java</artifactId>
-    <version>0.93.4</version>
+    <version>0.93.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -134,13 +134,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-api</artifactId>
-    <version>0.93.4</version>
+    <version>0.93.5</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-testlib</artifactId>
-    <version>0.93.4</version>
+    <version>0.93.5</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -239,12 +239,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.93.4</version>
+    <version>0.93.5</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.93.4</version>
+    <version>0.93.5</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For Spine-based dependencies please see [io.spine.dependency.local.Spine].
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.303")
+val validationVersion by extra("2.0.0-SNAPSHOT.305")


### PR DESCRIPTION
This PR adds `@Nullable` annotation to `TypeName` parameter in the generated implementations of `ValidatableMessage.validate(FieldPath, TypeName)` method.

Also, the generated implementations of the above method now check for nullability of `FieldPath` using `Objects.requireNonNull()`.

An example of the generated code:

```java
 @Override
    public java.util.Optional<io.spine.validate.ValidationError> validate(io.spine.base.FieldPath parentPath, io.spine.type.@org.checkerframework.checker.nullness.qual.Nullable TypeName parentName) {
        java.util.Objects.requireNonNull(parentPath);
        // ...
```

Addresses #201.