### PR TITLE
Validate documentation links

### DIFF
--- a/.agents/skills/check-links/SKILL.md
+++ b/.agents/skills/check-links/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: check-links
+description: >
+  Validate the Hugo documentation site under `docs/` for broken links.
+  Builds the site, starts the Hugo server locally, runs Lychee against the
+  rendered HTML using the repo's `lychee.toml`, and reports any broken URLs
+  grouped by source Markdown page. Use locally before pushing changes that
+  touch `docs/**`, when CI's `Check Links` job fails, or whenever the user
+  asks to "check doc links". Read-only with respect to the project sources.
+  Does **not** cover Javadoc/KDoc — a separate skill will handle that.
+---
+
+# Check links in the Hugo docs (repo-specific)
+
+You are the documentation link checker for this Spine Event Engine project.
+You build the site under `docs/`, serve it locally on port `1414`, run Lychee
+against the rendered HTML, and report broken URLs. You mirror what the
+`.github/workflows/check-links.yml` workflow does in CI: same Hugo version,
+same Lychee version, same Hugo environment (`development`), and the same
+`lychee.toml`. Two deliberate differences remain: the skill serves on port
+`1414` (CI uses `1313`) to avoid clashing with a developer's local
+`hugo server`, and the skill writes a local sentinel that CI does not.
+Both differences are harmless because `--base-url` is rewritten to match
+the local port and the sentinel is consumed only by the local `pre-pr`
+skill.
+
+### Pinned versions
+
+`.github/workflows/check-links.yml` is the **single source of truth** for the
+Hugo and Lychee pins. This file does not duplicate the current values
+because duplicates inevitably drift; see the workflow's `env:` block for
+the canonical `HUGO_VERSION` and `LYCHEE_VERSION_TAG`. The auto-download
+step (§2) reads `LYCHEE_VERSION_TAG` out of the workflow at runtime, so a
+workflow bump propagates automatically. Hugo is not auto-installed; the
+skill uses whichever `hugo` is on `$PATH` and only warns (does not block)
+if the installed version is older than the workflow's `HUGO_VERSION` —
+Hugo's HTML output is stable enough across minor versions that a small
+skew does not invalidate link-check results.
+
+The authoritative shared config is `lychee.toml` at the repo root. Do not
+fork its exclude list — fix the source link or, if the failing URL is a known
+flaky external endpoint, add it to `lychee.toml` once (the change applies to
+both the skill and CI).
+
+## When to run
+
+- Any change touches `docs/**` (including reference links, `embed-code`
+  blocks, sidenav YAML files, content under `docs/content/`).
+- A change touches `lychee.toml` itself.
+- CI reported broken links and you want a fast local repro.
+- The user asks to "check the doc links" or invokes `/check-links`.
+
+If none of the above is true, decline with a one-line note rather than
+running the (~30 s) build+check.
+
+## Tooling
+
+The skill needs four binaries:
+
+| Tool   | Purpose                                  | Install hint                  |
+|--------|------------------------------------------|-------------------------------|
+| Hugo   | Build and serve the site                 | `brew install hugo` (extended)|
+| Node   | Hugo theme dependencies (`npm install`)  | `brew install node`           |
+| npm    | Same                                     | bundled with Node             |
+| Lychee | Link checker                             | `brew install lychee`         |
+
+For **Lychee**, prefer a pre-installed binary on `$PATH`. If none is found,
+download the pinned release (see `LYCHEE_VERSION_TAG` in
+`.github/workflows/check-links.yml` — the dynamic-read pattern in step 2 below
+keeps this version in lock-step with CI) into
+`.agents/skills/check-links/.cache/lychee/` and use that path. The pinned
+version matches what the CI workflow uses, so behavior is identical.
+
+`.agents/skills/check-links/.cache/` is git-ignored (see `.gitignore`).
+
+## Procedure
+
+Execute the steps in order. On the first failure, stop, write a `FAIL`
+sentinel (step 8), and report the failure with the next action.
+
+### 1. Scope check
+
+Run `git diff <base>...HEAD --name-only` (default `<base>` = `master` unless
+the user provides another). If the change set has **no** files under `docs/**`
+and the user did not explicitly ask, decline and exit cleanly.
+
+### 2. Preflight binaries
+
+- `hugo version` → must succeed; capture the version. If missing, stop with
+  Must-fix: "Install Hugo extended (`brew install hugo`)." If installed but
+  older than the workflow's `HUGO_VERSION` (parse with
+  `grep '^  HUGO_VERSION:' .github/workflows/check-links.yml`), warn but
+  continue.
+- `node -v` and `npm -v` → must succeed. If missing, stop with Must-fix:
+  "Install Node 20+ (`brew install node`)."
+- `lychee --version` → if it succeeds, record the path and version.
+- If `lychee` is missing:
+  1. Read the canonical pin from the workflow file so the skill cannot drift
+     from CI:
+     ```bash
+     LYCHEE_VERSION_TAG=$(
+       grep -E '^\s+LYCHEE_VERSION_TAG:' .github/workflows/check-links.yml \
+         | sed -E 's/.*: *"?([^"]+)"?$/\1/'
+     )
+     ```
+     Expected shape: `lychee-vX.Y.Z` (the leading `lychee-` is part of the
+     upstream release tag, not a typo).
+  2. Determine platform via `uname -s` / `uname -m`. Map to the matching
+     Lychee asset (recent releases — `v0.24.2` and later — drop the
+     version from the asset filename):
+     - `Darwin` + `arm64`   → `lychee-aarch64-apple-darwin.tar.gz`
+     - `Darwin` + `x86_64`  → `lychee-x86_64-apple-darwin.tar.gz`
+     - `Linux`  + `x86_64`  → `lychee-x86_64-unknown-linux-gnu.tar.gz`
+     - `Linux`  + `aarch64` → `lychee-aarch64-unknown-linux-gnu.tar.gz`
+     - any other combination (e.g. Windows, FreeBSD, 32-bit) → stop with
+       Must-fix: "Unsupported platform for Lychee auto-download — install
+       Lychee manually (`brew install lychee` / `cargo install lychee`)
+       and rerun."
+  3. Ensure the cache directory exists *before* the download —
+     `mkdir -p .agents/skills/check-links/.cache/lychee/` —
+     because the path is git-ignored and absent on a fresh clone,
+     and `tar -xzf … -C <dir>` will fail with "no such file or
+     directory" if the target does not exist yet. This mirrors the
+     `mkdir -p lychee` that `check-links.yml` does before its own
+     extract step.
+  4. Download from
+     `https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION_TAG}/<asset>`
+     into `.agents/skills/check-links/.cache/lychee/` and extract
+     with `tar -xzf <asset> --strip-components=1 -C .agents/skills/check-links/.cache/lychee/`
+     so the binary lands at
+     `.agents/skills/check-links/.cache/lychee/lychee`.
+  5. Use `.agents/skills/check-links/.cache/lychee/lychee` for the rest of this run.
+  6. Print a one-line note: "Using auto-downloaded Lychee. For faster runs,
+     install with `brew install lychee`."
+
+### 3. Install Hugo deps
+
+Run `( cd docs/_preview && npm ci )`. We deliberately use `npm ci` (matching
+the CI workflow's `Install Dependencies` step in `check-links.yml`) rather
+than `npm install`:
+
+- `npm ci` installs exactly the versions pinned by `package-lock.json`;
+  `npm install` is allowed to update the lockfile and may resolve to
+  different transitive versions than CI, which defeats the "render
+  identical HTML to CI" goal.
+- If `package.json` and `package-lock.json` drift out of sync, `npm ci`
+  fails fast with a clear error rather than silently healing the
+  lockfile — a divergence we want to surface, not paper over.
+
+The helper script `docs/_script/install-dependencies` exists for interactive
+use but does a relative `cd _preview` and therefore only works when invoked
+from `docs/` — calling it from the repo root (the skill's default CWD)
+would fail with "No such file or directory: _preview".
+
+### 4. Build the site
+
+Run `( cd docs/_preview && hugo -e development )`.
+This emits `docs/_preview/public/**/*.html`. The `-e development` flag matches
+what CI uses in `check-links.yml` so the two builds render identical HTML.
+(The helper `docs/_script/hugo-build` exists for interactive use but defaults
+to `production`; we invoke `hugo` directly to keep the env in lock-step with CI.)
+
+### 5. Start the Hugo server in the background
+
+The server must survive across multiple `Bash` tool calls (steps 5 → 6 → 8
+typically run in separate shells), so we rely on `nohup` alone — a `trap …
+EXIT` would fire when *this* shell exits and kill the server before Lychee
+can query it. Teardown happens explicitly in step 8.
+
+Before launching, kill any leftover server from a previous crashed run so a
+stale process does not hold port `1414`:
+
+```bash
+pkill -F /tmp/check-links.hugo.pid 2>/dev/null || true
+rm -f /tmp/check-links.hugo.pid
+
+( cd docs/_preview && nohup hugo server --environment development --port 1414 \
+    > /tmp/check-links.hugo.out 2>&1 & echo $! > /tmp/check-links.hugo.pid )
+sleep 5
+
+# Verify the captured PID is alive before relying on it. `$!` for
+# `nohup foo &` is reliable on bash but not portable across shells; the
+# pgrep check turns a silent "Lychee fetches an empty port" failure into
+# a clear error.
+if ! pgrep -F /tmp/check-links.hugo.pid > /dev/null 2>&1; then
+  echo "ERROR: Hugo server failed to start. Tail of log:" >&2
+  tail -20 /tmp/check-links.hugo.out >&2 || true
+  exit 1
+fi
+```
+
+Port `1414` is chosen to avoid clashing with a developer's local `hugo server`
+(default `1313`). The `--environment development` flag matches CI's build env.
+
+### 6. Run Lychee
+
+```bash
+<lychee-path> --config lychee.toml --timeout 60 \
+  --base-url http://localhost:1414/ \
+  'docs/_preview/public/**/*.html'
+```
+
+Capture exit code. Any non-zero exit means at least one broken link.
+
+### 7. Report
+
+Group the broken URLs from Lychee's output by source page. To reverse-map
+an HTML path to its Markdown source:
+
+`docs/_preview/public/docs/<section>/<page>/index.html`
+↔ `docs/content/docs/<section>/<page>.md` (or `<page>/_index.md`).
+
+Report in this shape:
+
+```
+## Doc link check (<branch> vs <base>)
+
+Hugo: <version>
+Lychee: <version> (<path>)
+Pages scanned: <N>
+Broken URLs: <K>
+
+### docs/content/docs/<...>/<page>.md
+- <broken URL> — <Lychee reason / HTTP status>
+- <broken URL> — ...
+
+### docs/content/docs/<...>/<other-page>.md
+- ...
+```
+
+If `K == 0`, report a single line: "All links OK."
+
+### 8. Tear down and sentinel
+
+- Kill the Hugo server (and clean up its pid file):
+
+  ```bash
+  pkill -F /tmp/check-links.hugo.pid 2>/dev/null || true
+  rm -f /tmp/check-links.hugo.pid /tmp/check-links.hugo.out
+  ```
+
+  Run this even if Lychee failed — leaving a server on port `1414` would
+  poison the next invocation.
+- Write `.git/check-links.ok` at the repo root:
+
+  ```
+  head=<full HEAD SHA>
+  branch=<current branch>
+  status=PASS|FAIL
+  timestamp=<ISO-8601 UTC>
+  hugo=<version>
+  lychee=<version>
+  pages=<N>
+  broken=<K>
+  ```
+
+The sentinel is consumed by the `pre-pr` skill's reviewer step: when it
+sees a sentinel whose `head=` matches the current HEAD SHA and
+`status=PASS`, it skips re-dispatching `check-links` and records it
+as APPROVE with the note "cached from `.git/check-links.ok`". Any
+HEAD advance (commit, amend, rebase) invalidates the cache automatically.
+
+## Notes
+
+- This skill does **not** modify tracked sources. It does, however, write
+  several git-ignored build artifacts during a run — listed here so a future
+  reader does not mistake them for unrelated side-effects:
+  - `.agents/skills/check-links/.cache/lychee/` — auto-downloaded
+    Lychee binary, when the system Lychee was unavailable.
+  - `docs/_preview/node_modules/` — installed by `npm ci` in step 3.
+  - `docs/_preview/public/` — Hugo's rendered HTML (the corpus Lychee
+    scans).
+  - `docs/_preview/resources/` — Hugo's asset-pipeline cache.
+  - `.lycheecache` at the repo root — Lychee's per-URL result cache
+    (honoured for `max_cache_age = "3d"` per `lychee.toml`).
+  - `/tmp/check-links.hugo.{pid,out}` — server PID file and log, both
+    removed in step 8's teardown.
+
+  Every path above is matched by an existing `.gitignore` entry; none is
+  committed.
+- The `lychee.toml` exclude list is the single source of truth for flaky
+  external endpoints. If a real link must be excluded, add it there and
+  explain why in a comment so CI and local runs stay in sync.
+- The skill assumes the docs build succeeds. A Hugo build error is treated
+  the same as a link failure — surface it and stop.
+- The `include_verbatim = false` setting in `lychee.toml` skips links inside
+  code blocks. That is intentional today; flip it on if you specifically need
+  to validate examples.
+
+## Related skills
+
+- `review-docs` — prose, KDoc/Javadoc, and Markdown style review. Runs in
+  parallel with `check-links` when invoked by `pre-pr`.
+- `pre-pr` — composes the above and gates `gh pr create`.

--- a/.agents/skills/check-links/SKILL.md
+++ b/.agents/skills/check-links/SKILL.md
@@ -90,7 +90,7 @@ and exit cleanly.
 - `hugo version` → must succeed; capture the version. If missing, stop with
   Must-fix: "Install Hugo extended (`brew install hugo`)." If installed but
   older than the workflow's `HUGO_VERSION` (parse with
-  `grep '^  HUGO_VERSION:' .github/workflows/check-links.yml`), warn but
+  `grep -E '^\s+HUGO_VERSION:' .github/workflows/check-links.yml | sed -E 's/.*: *"?([^"]+)"?$/\1/'`), warn but
   continue.
 - `node -v` and `npm -v` → must succeed. If missing, stop with Must-fix:
   "Install Node 20+ (`brew install node`)."

--- a/.agents/skills/check-links/SKILL.md
+++ b/.agents/skills/check-links/SKILL.md
@@ -93,7 +93,8 @@ and exit cleanly.
   `grep -E '^\s+HUGO_VERSION:' .github/workflows/check-links.yml | sed -E 's/.*: *"?([^"]+)"?$/\1/'`), warn but
   continue.
 - `node -v` and `npm -v` → must succeed. If missing, stop with Must-fix:
-  "Install Node 20+ (`brew install node`)."
+  "Install Node (`brew install node`) at the major version pinned by
+  `node-version:` in `.github/workflows/check-links.yml`."
 - `lychee --version` → if it succeeds, record the path and version.
 - If `lychee` is missing:
   1. Read the canonical pin from the workflow file so the skill cannot drift

--- a/.agents/skills/check-links/SKILL.md
+++ b/.agents/skills/check-links/SKILL.md
@@ -7,7 +7,7 @@ description: >
   grouped by source Markdown page. Use locally before pushing changes that
   touch `docs/**`, when CI's `Check Links` job fails, or whenever the user
   asks to "check doc links". Read-only with respect to the project sources.
-  Does **not** cover Javadoc/KDoc — a separate skill will handle that.
+  Does **not** cover Javadoc/KDoc (out of scope for this skill).
 ---
 
 # Check links in the Hugo docs (repo-specific)
@@ -60,7 +60,7 @@ The skill needs four binaries:
 | Tool   | Purpose                                  | Install hint                  |
 |--------|------------------------------------------|-------------------------------|
 | Hugo   | Build and serve the site                 | `brew install hugo` (extended)|
-| Node   | Hugo theme dependencies (`npm install`)  | `brew install node`           |
+| Node   | Hugo theme dependencies (`npm ci`)       | `brew install node`           |
 | npm    | Same                                     | bundled with Node             |
 | Lychee | Link checker                             | `brew install lychee`         |
 
@@ -82,7 +82,8 @@ sentinel (step 8), and report the failure with the next action.
 
 Run `git diff <base>...HEAD --name-only` (default `<base>` = `master` unless
 the user provides another). If the change set has **no** files under `docs/**`
-and the user did not explicitly ask, decline and exit cleanly.
+and no changes to `lychee.toml`, and the user did not explicitly ask, decline
+and exit cleanly.
 
 ### 2. Preflight binaries
 

--- a/.agents/skills/pre-pr/SKILL.md
+++ b/.agents/skills/pre-pr/SKILL.md
@@ -61,9 +61,9 @@ Execute the steps in order. If a step fails, stop, write a `FAIL` sentinel
   - **proto** — any `*.proto` file changed.
   - **code** — any `*.kt`, `*.kts`, or `*.java` file changed.
   - **docs** — any `*.md` file or doc-only edits inside sources changed.
-  - **site** — any file under `docs/**` changed (independent of **docs**;
-    triggers the Hugo link check; pure `README.md` edits or KDoc-only
-    changes do *not* count as **site**).
+  - **site** — any file under `docs/**` changed, or `lychee.toml` changed
+    (independent of **docs**; triggers the Hugo link check; pure `README.md`
+    edits or KDoc-only changes do *not* count as **site**).
   - **deps** — any file under `buildSrc/src/main/kotlin/io/spine/dependency/`
     changed.
 

--- a/.agents/skills/pre-pr/SKILL.md
+++ b/.agents/skills/pre-pr/SKILL.md
@@ -61,9 +61,9 @@ Execute the steps in order. If a step fails, stop, write a `FAIL` sentinel
   - **proto** — any `*.proto` file changed.
   - **code** — any `*.kt`, `*.kts`, or `*.java` file changed.
   - **docs** — any `*.md` file or doc-only edits inside sources changed.
-  - **site** — any file under `docs/**` changed (subset of **docs** that
+  - **site** — any file under `docs/**` changed (independent of **docs**;
     triggers the Hugo link check; pure `README.md` edits or KDoc-only
-    changes do *not* count).
+    changes do *not* count as **site**).
   - **deps** — any file under `buildSrc/src/main/kotlin/io/spine/dependency/`
     changed.
 
@@ -103,8 +103,8 @@ Dispatch the relevant reviewers concurrently and collect their verdicts:
 
 - Always: `kotlin-review` (if **code** changed) and `review-docs` (if
   **docs** or KDoc changed).
-- If **site** changed: `check-links` (runs in parallel with `review-docs`),
-  **unless** the sentinel short-circuit below applies.
+- If **site** changed: `check-links` (runs in parallel with any other
+  dispatched reviewers), **unless** the sentinel short-circuit below applies.
 - If **deps** changed: `dependency-audit`.
 
 **`check-links` sentinel short-circuit.** Before dispatching

--- a/.agents/skills/pre-pr/SKILL.md
+++ b/.agents/skills/pre-pr/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Run the pre-PR checklist for this repo: apply the version gate only when
   the repository has a root `version.gradle.kts`, run the configured
   build/check command per `.agents/running-builds.md`, and invoke the
-  configured reviewers (`kotlin-review`, `review-docs`, `dependency-audit`)
-  against the branch diff. On success, write a sentinel file at
+  configured reviewers (`kotlin-review`, `review-docs`, `dependency-audit`,
+  `check-links`) against the branch diff. On success, write a sentinel file at
   `.git/pre-pr.ok` so the `gh pr create` hook can verify the checklist ran
   for the current HEAD. Use before opening a PR, or when CI rejected a
   branch and you want a fast local repro.
@@ -32,7 +32,9 @@ The authoritative standards live in `.agents/`:
 - `.agents/safety-rules.md` and `.agents/advanced-safety-rules.md` — hard
   constraints checked by the reviewers.
 - The reviewer skills/agents themselves: `kotlin-review` (Claude agent),
-  `review-docs` (skill + Claude agent), `dependency-audit` (Claude agent).
+  `review-docs` (skill + Claude agent), `dependency-audit` (Claude agent),
+  `check-links` (skill — runs Lychee against the rendered Hugo site
+  under `docs/`).
 
 ## Procedure
 
@@ -59,6 +61,9 @@ Execute the steps in order. If a step fails, stop, write a `FAIL` sentinel
   - **proto** — any `*.proto` file changed.
   - **code** — any `*.kt`, `*.kts`, or `*.java` file changed.
   - **docs** — any `*.md` file or doc-only edits inside sources changed.
+  - **site** — any file under `docs/**` changed (subset of **docs** that
+    triggers the Hugo link check; pure `README.md` edits or KDoc-only
+    changes do *not* count).
   - **deps** — any file under `buildSrc/src/main/kotlin/io/spine/dependency/`
     changed.
 
@@ -98,7 +103,20 @@ Dispatch the relevant reviewers concurrently and collect their verdicts:
 
 - Always: `kotlin-review` (if **code** changed) and `review-docs` (if
   **docs** or KDoc changed).
+- If **site** changed: `check-links` (runs in parallel with `review-docs`),
+  **unless** the sentinel short-circuit below applies.
 - If **deps** changed: `dependency-audit`.
+
+**`check-links` sentinel short-circuit.** Before dispatching
+`check-links`, read `.git/check-links.ok` (if present) and parse the
+`head=` and `status=` fields. If `head=` equals the current HEAD SHA (full,
+not short) and `status=PASS`, skip the dispatch and record the reviewer as
+`APPROVE` with the note "cached from `.git/check-links.ok`". Any HEAD
+advance — commit, amend, rebase — automatically invalidates the cache because
+the recorded SHA no longer matches. If the file is missing, malformed, or the
+`head=` does not match, dispatch the reviewer normally. Other reviewers do not
+use this pattern today; only `check-links` does, because its rebuild+serve
+cycle is slow (~30 s) and the result is deterministic for a given HEAD.
 
 Pass each reviewer the base ref, changed-file list, build/check result, and
 version-check result. When the version check is `N/A`, say explicitly:
@@ -145,13 +163,14 @@ Report in this shape:
 ```
 ## Pre-PR checklist (<branch> vs <base>)
 
-| Check         | Status | Notes                                  |
-|---------------|--------|----------------------------------------|
-| Version check | …      | <old> → <new>, introduced, or N/A      |
-| Build/check   | …      | <command>                              |
-| kotlin-review | …      | <verdict + count of Must/Should>       |
-| review-docs   | …      | <verdict + count of Must/Should>       |
-| dep audit     | …      | <verdict + count of Must/Should>       |
+| Check            | Status | Notes                                  |
+|------------------|--------|----------------------------------------|
+| Version check    | …      | <old> → <new>, introduced, or N/A      |
+| Build/check      | …      | <command>                              |
+| kotlin-review    | …      | <verdict + count of Must/Should>       |
+| review-docs      | …      | <verdict + count of Must/Should>       |
+| check-links  | …      | <K broken URLs across N pages>         |
+| dep audit        | …      | <verdict + count of Must/Should>       |
 
 **Overall: PASS|FAIL**
 Sentinel: .git/pre-pr.ok (status=PASS|FAIL, head=<SHA>)

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -40,8 +40,8 @@ repo.
   `docs/content/docs/validation/developer/architecture.md`.
 - [ ] Verify the canonical GitHub URL for `template_string.proto` by browsing
   `https://github.com/SpineEventEngine/base-libraries/tree/master/src/main/proto/spine/string/`.
-- [ ] In `runtime-library.md`: update the `[error-message-proto]` reference
-  definition to point at the `SpineEventEngine/base` URL. Rename the
+- [ ] In `runtime-library.md`: update the broken `error_message.proto` link to point at
+  the `SpineEventEngine/base-libraries` URL for `template_string.proto`. Rename the
   reference id to `[template-string-proto]` and the prose mention from
   "`error_message.proto`" to "`template_string.proto`".
 - [ ] In `architecture.md`: same fix.

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -1,0 +1,341 @@
+---
+slug: check-links
+branch: validate-doc-links
+owner: claude
+status: in-review
+started: 2026-05-22
+---
+
+## Context
+
+The Spine `validation` repo's Hugo site under `docs/` accumulates link rot
+silently. A concrete example: `docs/content/docs/validation/developer/runtime-library.md`
+references `error_message.proto` at a path that no longer exists in this repo —
+the `TemplateString` type it describes actually lives in the sibling
+`SpineEventEngine/base` repo. The same broken reference appears in
+`architecture.md`. We need both a local pre-push check and a CI gate, mirroring
+the well-tested setup in the sibling `spine.io` repo
+(`/Users/sanders/Projects/Spine/spine.io/lychee.toml`,
+`/Users/sanders/Projects/Spine/spine.io/.github/workflows/check-links.yml`).
+
+The new skill is scoped to the Hugo Markdown docs only. A separate skill for
+KDoc/Javadoc HTML is out of scope here and will be planned independently. The
+`../config` fan-out is also out of scope — it will happen separately in that
+repo.
+
+## Decisions (approved 2026-05-22)
+
+- **Lychee binary** — prefer installed, fall back to auto-download pinned
+  `v0.15.1` into `.agents/skills/check-links/.cache/lychee/`.
+- **`pre-pr` wiring** — yes, wire it in.
+- **Hugo server port** — 1414 (avoid clashing with developer's default 1313).
+
+## Plan
+
+### 1. Fix the two broken doc links
+
+- [ ] Read both files end-to-end first to understand the surrounding prose:
+  `docs/content/docs/validation/developer/runtime-library.md`,
+  `docs/content/docs/validation/developer/architecture.md`.
+- [ ] Verify the canonical GitHub URL for `template_string.proto` by browsing
+  `https://github.com/SpineEventEngine/base/tree/master/src/main/proto/spine/string/`.
+- [ ] In `runtime-library.md`: update the `[error-message-proto]` reference
+  definition to point at the `SpineEventEngine/base` URL. Rename the
+  reference id to `[template-string-proto]` and the prose mention from
+  "`error_message.proto`" to "`template_string.proto`".
+- [ ] In `architecture.md`: same fix.
+- [ ] Sanity-check there are no other lingering `error_message.proto` mentions
+  via `Grep`.
+
+### 2. Add Lychee config at repo root
+
+- [ ] Create `lychee.toml` as a near-copy of
+  `/Users/sanders/Projects/Spine/spine.io/lychee.toml`. Keep its exclude
+  list unchanged.
+
+### 3. Add CI workflow
+
+- [ ] Create `.github/workflows/check-links.yml`, adapted from
+  `/Users/sanders/Projects/Spine/spine.io/.github/workflows/check-links.yml`.
+- [ ] Diffs vs. source: `working-directory` → `docs`/`docs/_preview`;
+  Lychee glob `'docs/public/**/*.html'`; `paths:` filter on `pull_request`
+  for `['docs/**', '.github/workflows/check-links.yml', 'lychee.toml']`.
+- [ ] Preserve pinned versions: `HUGO_VERSION=0.161.1`,
+  `LYCHEE_VERSION_TAG=v0.15.1`. Preserve both caches.
+
+### 4. Create `check-links` skill
+
+- [ ] New file: `.agents/skills/check-links/SKILL.md`.
+- [ ] Procedure: scope check → preflight binaries (Lychee prefer-installed,
+  fallback to download) → install deps → Hugo build → Hugo serve on port
+  1414 → Lychee against `docs/public/**/*.html` → tear down → report grouped
+  by source `.md` → sentinel `.git/check-links.ok` on PASS.
+
+### 5. Wire into `pre-pr` skill
+
+- [ ] Edit `.agents/skills/pre-pr/SKILL.md`: add `docs/**` slice in the
+  classifier; invoke `check-links` in parallel with `review-docs` when
+  `docs/**` changed; include in verdict union; append to sentinel
+  `reviewers=` field; add row to verdict table.
+
+### 6. Update `.gitignore`
+
+- [ ] Add `.agents/skills/check-links/.cache/` to `.gitignore` (Lychee binary cache).
+
+### 7. Verification (end-to-end)
+
+- [ ] **Local skill smoke test**: temporarily revert the link fix on a scratch
+  commit; run `/check-links`; expect non-zero exit naming the broken URL
+  and the source page. Re-apply the fix; rerun; expect clean exit.
+- [ ] **CI smoke test**: push the branch; observe the new `check-links` job
+  appear on the PR; it must be green with the fix applied.
+- [ ] **pre-pr integration**: run `/pre-pr` on the branch; confirm the
+  reviewers table now lists `check-links` and that the sentinel records
+  it.
+
+## Critical files
+
+- `docs/content/docs/validation/developer/runtime-library.md` (link fix)
+- `docs/content/docs/validation/developer/architecture.md` (link fix)
+- `lychee.toml` (new, repo root)
+- `.github/workflows/check-links.yml` (new)
+- `.agents/skills/check-links/SKILL.md` (new)
+- `.agents/skills/pre-pr/SKILL.md` (edit)
+- `.gitignore` (edit — add `.agents/skills/check-links/.cache/`)
+
+## Log
+- 2026-05-22 — drafted, presented to user, approved with all three open
+  questions resolved (Lychee fallback download / pre-pr wiring yes / port 1414).
+- 2026-05-22 — execution started.
+- 2026-05-22 — Hugo actually publishes to `docs/_preview/public/**`, not
+  `docs/public/**` (the latter is a stale dir from an earlier config). Lychee
+  glob updated everywhere.
+- 2026-05-22 — User-supplied canonical URL is
+  `SpineEventEngine/base-libraries`, not `SpineEventEngine/base`. Both docs
+  updated; WebFetch confirmed HTTP 200.
+- 2026-05-22 — Lychee v0.15.1 ships no arm64 macOS binary, so the skill's
+  fallback download path can't work on Apple Silicon. Bumped the pin to
+  `lychee-v0.24.2` in both `check-links.yml` and the skill. Asset names in
+  that release drop the version-in-filename (e.g.
+  `lychee-aarch64-apple-darwin.tar.gz`); release tag is `lychee-v0.24.2`.
+  Extract with `--strip-components=1` so the binary lands at
+  `.agents/skills/check-links/.cache/lychee/lychee`.
+- 2026-05-22 — Verified end-to-end on macOS arm64: downloaded Lychee 0.24.2
+  → `hugo` (extended 0.161.1) build → `hugo server --port 1414` → Lychee
+  against `docs/_preview/public/**/*.html`. **616 links checked, 0 errors.**
+- 2026-05-22 — Lychee 0.24.2 deprecated `--base`; switched to `--base-url`
+  in both the workflow and the skill.
+- 2026-05-22 — Self-review pass on SKILL + workflow + lychee.toml. Fixes:
+  - SKILL: softened the "green here means green there" claim and listed the
+    two deliberate differences (port 1414 vs 1313, local sentinel).
+  - SKILL: aligned the build/serve commands to use `-e development` /
+    `--environment development` so the skill renders exactly what CI renders.
+    Replaced `docs/_script/hugo-build` with explicit `hugo -e development`
+    (the helper script defaults to `production`).
+  - SKILL: added Linux aarch64 row to the platform map; unsupported platforms
+    (Windows / FreeBSD / 32-bit) now stop with a Must-fix asking the user to
+    install Lychee manually instead of falling through silently.
+  - SKILL: install the kill-trap **before** backgrounding the Hugo server so
+    a failure between the subshell exit and the original trap line cannot
+    leak a process holding port 1414. Noted the trap-doesn't-survive-Bash
+    rule explicitly.
+  - Workflow: added `cancel-in-progress: true` to `concurrency` so each PR
+    push cancels the previous run instead of queueing.
+  - Workflow: bumped `actions/setup-node@v3` → `@v4` to match the other
+    actions which are already on `@v4`.
+  - Workflow: rekeyed Lychee results cache to
+    `cache-lychee-${{ runner.os }}-${{ hashFiles('lychee.toml') }}` with a
+    `restore-keys:` fallback, so exclude-list edits invalidate cached `200`s
+    deterministically. Included `LYCHEE_VERSION_TAG` in the binary cache key
+    for the same reason.
+  - Workflow: added `--strip-components=1` (and `-z`) to the tar extract so
+    the binary lands at `lychee/lychee` instead of
+    `lychee/lychee-<triple>/lychee` — matching the skill and what the next
+    "Check links" step expects on a cold cache.
+  - `lychee.toml`: removed the broad
+    `raw.githubusercontent.com/SpineEventEngine/*` exclude (it would mask
+    the very class of bug this skill exists to catch). Existing
+    `max_retries=3` / `retry_wait_time=2` should absorb transient 429s; a
+    comment in the file calls out the deliberate omission.
+- 2026-05-22 — Second self-review pass. Fixes:
+  - SKILL: the "same Hugo version, same Lychee version" claim used to be
+    aspirational — neither value was pinned anywhere in this file. Added a
+    "Pinned versions" subsection saying `check-links.yml` is the single
+    source of truth, and rewrote step 2 so the auto-download path **reads
+    `LYCHEE_VERSION_TAG` out of the workflow at runtime** via `grep|sed`.
+    Hugo similarly read from the workflow's `HUGO_VERSION` for a "your
+    Hugo is older than CI" warning. Drift between skill and CI is now
+    impossible for the version pins.
+  - SKILL: the previous trap-based teardown had a fatal bug — `trap … EXIT`
+    fires when *this* shell exits, and Claude Code's Bash tool gives each
+    invocation its own shell. So running step 5 (start server) and step 6
+    (run Lychee) in separate Bash calls killed Hugo before Lychee could
+    query it. Dropped the trap; switched to `nohup`-only (which detaches
+    the server from the spawning shell). Step 5 now also `pkill -F`s any
+    leftover server from a previous crashed run before launching. Step 8
+    does the explicit kill with the same `pkill -F` (always runs, even on
+    Lychee failure, so port 1414 isn't leaked).
+  - Workflow: added `restore-keys: ${{ runner.os }}-${{ env.LYCHEE_VERSION_TAG }}-`
+    fallback for the Lychee binary cache so a release-filename tweak can
+    reuse the existing cached binary for the same version-tag instead of
+    paying for a fresh download.
+  - Workflow: made the Hugo server's `--port 1313` explicit so its coupling
+    with the next step's `--base-url http://localhost:1313/` is visible at
+    the call site. Comment in the workflow explains the lock-step.
+  - `lychee.toml`: fixed `no_progress = false` → `true` (the comment said
+    "don't show progress bar" but the value asked to show it — Lychee's
+    `no_progress` semantics invert what one might expect).
+  - `lychee.toml`: documented the `429` acceptance — it's a deliberate
+    rate-limit tradeoff, not a typo, and the comment explains the rare
+    downside (a genuinely-broken URL that also returns `429` would pass).
+- 2026-05-22 — Third self-review pass. Fixes:
+  - SKILL: dropped the concrete `HUGO_VERSION=0.161.1` /
+    `LYCHEE_VERSION_TAG=lychee-v0.24.2` values from the preamble. They
+    contradicted the "don't edit here" warning — duplicating pins is the
+    very thing the "single source of truth" framing exists to prevent.
+    Preamble now just points to `check-links.yml`'s `env:` block.
+  - SKILL: step 3 replaced `docs/_script/install-dependencies` with inline
+    `( cd docs/_preview && npm install )`. The helper script does a
+    relative `cd _preview` so it only works from `docs/`; the skill's
+    default CWD is the repo root, where the helper would fail with
+    "No such file or directory: _preview". Annotated step 3 with the
+    reason.
+  - SKILL: step 5 captures `$!` to a pid file and then verifies the PID
+    via `pgrep -F` before relying on it. Without this check a silent Hugo
+    startup failure (port already bound, missing module, etc.) becomes a
+    confusing "Lychee fetches an empty port" failure 30s later. Now it's
+    a clear error with a log tail at the actual failure point.
+  - SKILL: step 8's sentinel-consumer wording now describes the planned
+    `pre-pr` short-circuit precisely — `head=` match + `status=PASS`
+    skips re-dispatch and records APPROVE with note "cached from
+    `.git/check-links.ok`". Avoids the "orphaned sentinel" issue
+    where the skill claimed integration that didn't exist.
+  - `pre-pr/SKILL.md`: implemented the sentinel short-circuit in step 4
+    to make the SKILL.md claim true. Explicitly notes that other
+    reviewers do not use this pattern (only `check-links` does,
+    because its rebuild+serve cycle is slow and the result is
+    deterministic for a given HEAD).
+  - Workflow: removed the noisy "Check if the cache file exists"
+    diagnostic step. It only existed as a debugging breadcrumb during
+    initial bring-up and added log noise without any actionable signal —
+    `actions/cache@v4` already reports cache-hit status.
+  - `lychee.toml`: header comment now references the canonical
+    `SpineEventEngine/SpineEventEngine.github.io` repo, not the bare
+    `spine.io` shorthand.
+- 2026-05-22 — Fourth self-review pass. Six fixes:
+  - SKILL step 2 (Lychee auto-download): added an explicit
+    `mkdir -p .agents/skills/check-links/.cache/lychee/` substep
+    before the tar extract. On a fresh clone the cache dir does not
+    exist (it is git-ignored), and `tar -xzf <asset> -C <dir>` would
+    fail with "no such file or directory" — the previous
+    end-to-end success worked only because the dir was already
+    present locally. Renumbered the surrounding substeps.
+  - SKILL step 3 (install Hugo deps): switched
+    `( cd docs/_preview && npm install )` to `npm ci` to match the
+    `Install Dependencies` step in `check-links.yml`. Rationale (in
+    the SKILL): `npm install` may mutate the lockfile and resolve
+    different transitive versions than CI; `npm ci` pins to
+    `package-lock.json` and fails fast on lockfile drift instead of
+    silently healing it.
+  - Workflow: removed the standalone `Cache dependencies` step and
+    folded its job into `actions/setup-node@v4` via
+    `cache: 'npm'` + `cache-dependency-path:
+    docs/_preview/package-lock.json`. One source of truth for the
+    npm cache key, no drift between the two layers.
+  - Workflow: the Hugo modules cache step pointed at
+    `path: /tmp/hugo_cache`, but Hugo's default cacheDir on Linux
+    is `~/.cache/hugo_cache` (or `$TMPDIR/hugo_cache_$USER`) —
+    nothing ever landed in `/tmp/hugo_cache` and the cache was a
+    silent no-op every run. Fixed by adding
+    `HUGO_CACHEDIR: /tmp/hugo_cache` to the job `env:` block so
+    Hugo actually writes where the cache step restores from. Also
+    narrowed the cache key from `hashFiles('**/go.sum')` to
+    `hashFiles('docs/**/go.sum')` since those are the only `go.sum`
+    files in the repo and the broader glob was misleading.
+  - Workflow: the Lychee `Download` and `Extract` steps gated on
+    `steps.cache-lychee.outputs.cache-hit != 'true'`, which is only
+    `'true'` on an EXACT key match. A restore via `restore-keys`
+    reports `cache-hit == 'false'` per `actions/cache` docs, so the
+    download would re-run even when the binary was present —
+    defeating the fallback that was added in round 1. Switched the
+    `if:` guards to `hashFiles('lychee/lychee') == ''`, which only
+    triggers the download when the binary is actually absent.
+    Comment in the workflow explains the rationale.
+  - `lychee.toml`: the exclude entries are Rust regexes (per
+    Lychee docs), not shell globs. The previous entries used
+    unescaped dots and bare `*` (e.g. `fonts.googleapis.com/*`),
+    which means "any char between `fonts` and `googleapis`,
+    zero-or-more slashes at the end" — silent over-match that
+    could mask real broken links to URLs of the same shape (e.g.
+    `fontsXgoogleapisYcomZ/...`). Rewrote every pattern with
+    escaped dots and `/.*` for the path suffix. Switched the TOML
+    strings from double-quoted to single-quoted (literal strings)
+    so the backslashes stay literal — TOML basic strings treat
+    `\.` as an unrecognized escape. Added a header block above the
+    `exclude = [` line documenting the regex semantics.
+    **Empirically verified** with `lychee --dump`:
+    `fonts.googleapis.com/css?family=Roboto` and `x.com/notify` are
+    correctly excluded by the new config, `github.com/owner/repo`
+    passes through. Without `--config`, all three pass — confirming
+    the exclusion is firing from our patterns, not from Lychee
+    built-ins.
+- 2026-05-22 — Re-verified end-to-end after round-4 edits:
+  `( cd docs/_preview && hugo -e development )` →
+  `hugo server --environment development --port 1414` (PID survived
+  across separate Bash calls; `pgrep -F` verification passed) →
+  `lychee --config lychee.toml --base-url http://localhost:1414/
+  'docs/_preview/public/**/*.html'`. **616 links, 0 errors, exit 0.**
+- 2026-05-22 — Fifth self-review pass. Four fixes:
+  - SKILL "Tooling" section (lines 67–72): removed the literal
+    `v0.24.2` reference. It contradicted the "Pinned versions"
+    subsection above (`check-links.yml` is the single source of
+    truth) and would drift the moment the workflow pin is bumped —
+    exactly the failure mode the dynamic `grep|sed` read in step 2
+    was introduced to prevent. The Tooling sentence now points at
+    `LYCHEE_VERSION_TAG` in the workflow.
+  - SKILL "Notes" bullet about outside-`.git/` files: the previous
+    claim ("only files outside `.git/` are `.cache/` and `/tmp/`")
+    was wrong. The skill also creates `docs/_preview/node_modules/`
+    (`npm ci`), `docs/_preview/public/` + `docs/_preview/resources/`
+    (`hugo -e development`), and `.lycheecache` at the repo root
+    (Lychee). All git-ignored (verified against `.gitignore` and
+    `docs/.gitignore`), but listing them prevents future readers
+    from mistaking a build artifact for an unexpected side-effect.
+    Reworded "does not modify project sources" → "does not modify
+    tracked sources" to be technically precise.
+  - Workflow: the `Start Hugo server` step had no readiness check —
+    only `nohup … & sleep 5`. A silent startup failure (port bind,
+    missing Hugo module, build error after `nohup` returns 0)
+    would surface 60 s later as "every URL unreachable" Lychee
+    errors. Added a `curl -sf http://localhost:1313/` probe after
+    the sleep that exits non-zero with a `cat nohup.out / nohup.err`
+    dump if Hugo isn't actually serving. Mirrors the spirit of the
+    skill's `pgrep -F` guard (strictly stronger, since `curl`
+    catches "process alive but not serving" too).
+  - `lychee.toml`: two exclude entries — `clients4\.google\.com/`
+    and `ssl\.gstatic\.com/` — didn't have the trailing `/.*` that
+    the header comment documents as the convention and that every
+    other entry follows. They still matched via substring regex,
+    but the inconsistency was a footgun for future edits. Aligned
+    to `clients4\.google\.com/.*` and `ssl\.gstatic\.com/.*`.
+    Empirically verified via `lychee --dump` (running from `/tmp`
+    to bypass CWD config auto-discovery): both URLs are now
+    excluded by the config, `github.com/owner/repo` still passes.
+- 2026-05-22 — Re-verified end-to-end after round-5 edits:
+  build → `hugo server --port 1414` → `pgrep -F` + `curl -sf
+  http://localhost:1414/` both pass → Lychee 616/0/exit 0. The
+  `--dump` probe confirms the two re-aligned exclude entries still
+  filter their domains.
+- 2026-05-22 — Rename pass: workflow `proof-links.yml` →
+  `check-links.yml` (file + `name:` field `Proof Links` →
+  `Check Links` + job key `proof-links:` → `check-links:`); skill
+  `link-check-docs` → `check-links` (directory, frontmatter `name:`,
+  all internal references); sentinel `.git/link-check-docs.ok` →
+  `.git/check-links.ok` (skill + `pre-pr/SKILL.md` consumer);
+  `.gitignore` comments + cache path; this task file's slug, body,
+  and prior log entries.
+- 2026-05-22 — Dropped all references to the future KDoc/Javadoc
+  link-check skill from `SKILL.md` (description preamble + the
+  "Related skills" bullet) and from this task file's Context
+  section. Rationale: that skill doesn't exist yet, naming it now
+  pre-commits the design before its own planning round.

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -62,7 +62,7 @@ repo.
   Lychee glob `'docs/public/**/*.html'`; `paths:` filter on `pull_request`
   for `['docs/**', '.github/workflows/check-links.yml', 'lychee.toml']`.
 - [ ] Preserve pinned versions: `HUGO_VERSION=0.161.1`,
-  `LYCHEE_VERSION_TAG=v0.15.1`. Preserve both caches.
+  `LYCHEE_VERSION_TAG=lychee-v0.24.2`. Preserve both caches.
 
 ### 4. Create `check-links` skill
 

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -59,7 +59,7 @@ repo.
 - [ ] Create `.github/workflows/check-links.yml`, adapted from
   `/Users/sanders/Projects/Spine/spine.io/.github/workflows/check-links.yml`.
 - [ ] Diffs vs. source: `working-directory` → `docs`/`docs/_preview`;
-  Lychee glob `'docs/public/**/*.html'`; `paths:` filter on `pull_request`
+  Lychee glob `'docs/_preview/public/**/*.html'`; `paths:` filter on `pull_request`
   for `['docs/**', '.github/workflows/check-links.yml', 'lychee.toml']`.
 - [ ] Preserve pinned versions: `HUGO_VERSION=0.161.1`,
   `LYCHEE_VERSION_TAG=lychee-v0.24.2`. Preserve both caches.

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -25,8 +25,9 @@ repo.
 
 ## Decisions (approved 2026-05-22)
 
-- **Lychee binary** — prefer installed, fall back to auto-download pinned
-  `v0.15.1` into `.agents/skills/check-links/.cache/lychee/`.
+- **Lychee binary** — prefer installed, fall back to auto-download the version
+  pinned by `LYCHEE_VERSION_TAG` in `check-links.yml` into
+  `.agents/skills/check-links/.cache/lychee/`.
 - **`pre-pr` wiring** — yes, wire it in.
 - **Hugo server port** — 1414 (avoid clashing with developer's default 1313).
 
@@ -38,7 +39,7 @@ repo.
   `docs/content/docs/validation/developer/runtime-library.md`,
   `docs/content/docs/validation/developer/architecture.md`.
 - [ ] Verify the canonical GitHub URL for `template_string.proto` by browsing
-  `https://github.com/SpineEventEngine/base/tree/master/src/main/proto/spine/string/`.
+  `https://github.com/SpineEventEngine/base-libraries/tree/master/src/main/proto/spine/string/`.
 - [ ] In `runtime-library.md`: update the `[error-message-proto]` reference
   definition to point at the `SpineEventEngine/base` URL. Rename the
   reference id to `[template-string-proto]` and the prose mention from

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -12,7 +12,7 @@ The Spine `validation` repo's Hugo site under `docs/` accumulates link rot
 silently. A concrete example: `docs/content/docs/validation/developer/runtime-library.md`
 references `error_message.proto` at a path that no longer exists in this repo —
 the `TemplateString` type it describes actually lives in the sibling
-`SpineEventEngine/base` repo. The same broken reference appears in
+`SpineEventEngine/base-libraries` repo. The same broken reference appears in
 `architecture.md`. We need both a local pre-push check and a CI gate, mirroring
 the well-tested setup in the sibling `spine.io` repo
 (`/Users/sanders/Projects/Spine/spine.io/lychee.toml`,
@@ -41,7 +41,7 @@ repo.
 - [ ] Verify the canonical GitHub URL for `template_string.proto` by browsing
   `https://github.com/SpineEventEngine/base-libraries/tree/master/src/main/proto/spine/string/`.
 - [ ] In `runtime-library.md`: update the `[error-message-proto]` reference
-  definition to point at the `SpineEventEngine/base` URL. Rename the
+  definition to point at the `SpineEventEngine/base-libraries` URL. Rename the
   reference id to `[template-string-proto]` and the prose mention from
   "`error_message.proto`" to "`template_string.proto`".
 - [ ] In `architecture.md`: same fix.
@@ -59,17 +59,17 @@ repo.
 - [ ] Create `.github/workflows/check-links.yml`, adapted from
   `/Users/sanders/Projects/Spine/spine.io/.github/workflows/check-links.yml`.
 - [ ] Diffs vs. source: `working-directory` → `docs`/`docs/_preview`;
-  Lychee glob `'docs/public/**/*.html'`; `paths:` filter on `pull_request`
+  Lychee glob `'docs/_preview/public/**/*.html'`; `paths:` filter on `pull_request`
   for `['docs/**', '.github/workflows/check-links.yml', 'lychee.toml']`.
 - [ ] Preserve pinned versions: `HUGO_VERSION=0.161.1`,
-  `LYCHEE_VERSION_TAG=v0.15.1`. Preserve both caches.
+  `LYCHEE_VERSION_TAG=lychee-v0.24.2`. Preserve both caches.
 
 ### 4. Create `check-links` skill
 
 - [ ] New file: `.agents/skills/check-links/SKILL.md`.
 - [ ] Procedure: scope check → preflight binaries (Lychee prefer-installed,
   fallback to download) → install deps → Hugo build → Hugo serve on port
-  1414 → Lychee against `docs/public/**/*.html` → tear down → report grouped
+  1414 → Lychee against `docs/_preview/public/**/*.html` → tear down → report grouped
   by source `.md` → sentinel `.git/check-links.ok` on PASS.
 
 ### 5. Wire into `pre-pr` skill

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -12,7 +12,7 @@ The Spine `validation` repo's Hugo site under `docs/` accumulates link rot
 silently. A concrete example: `docs/content/docs/validation/developer/runtime-library.md`
 references `error_message.proto` at a path that no longer exists in this repo —
 the `TemplateString` type it describes actually lives in the sibling
-`SpineEventEngine/base` repo. The same broken reference appears in
+`SpineEventEngine/base-libraries` repo. The same broken reference appears in
 `architecture.md`. We need both a local pre-push check and a CI gate, mirroring
 the well-tested setup in the sibling `spine.io` repo
 (`/Users/sanders/Projects/Spine/spine.io/lychee.toml`,

--- a/.agents/tasks/check-links.md
+++ b/.agents/tasks/check-links.md
@@ -69,7 +69,7 @@ repo.
 - [ ] New file: `.agents/skills/check-links/SKILL.md`.
 - [ ] Procedure: scope check → preflight binaries (Lychee prefer-installed,
   fallback to download) → install deps → Hugo build → Hugo serve on port
-  1414 → Lychee against `docs/public/**/*.html` → tear down → report grouped
+  1414 → Lychee against `docs/_preview/public/**/*.html` → tear down → report grouped
   by source `.md` → sentinel `.git/check-links.ok` on PASS.
 
 ### 5. Wire into `pre-pr` skill

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,161 @@
+name: Check Links
+
+# Trigger only when the docs site, the link checker config, or this workflow
+# itself changes — unrelated PRs do not need to pay the build+check cost.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'lychee.toml'
+      - '.github/workflows/check-links.yml'
+  workflow_dispatch:
+
+env:
+  HUGO_VERSION: 0.161.1
+  LYCHEE_RELEASE: "lychee-x86_64-unknown-linux-gnu.tar.gz"
+  LYCHEE_VERSION_TAG: "lychee-v0.24.2"
+  # Force Hugo to write its module cache where the cache step actually
+  # restores from. Hugo's default on Linux is `~/.cache/hugo_cache`
+  # (or `$TMPDIR/hugo_cache_$USER`), neither of which matches the
+  # `path: /tmp/hugo_cache` cache step below — without this env var,
+  # the cache would silently never hit.
+  HUGO_CACHEDIR: /tmp/hugo_cache
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      # `actions/setup-node@v4` ships with built-in npm caching that hashes
+      # the lockfile and restores `~/.npm`. We use that instead of a
+      # standalone `actions/cache@v4` block so there is only one source of
+      # truth for the cache key (no drift between two layers).
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: docs/_preview/package-lock.json
+
+      # `HUGO_CACHEDIR=/tmp/hugo_cache` (set in `env:` above) makes Hugo
+      # actually write to the path this step restores from. The key hashes
+      # `docs/_preview/go.sum` + `docs/go.sum`, so adding/removing a Hugo
+      # module invalidates the cache deterministically.
+      - name: Cache Hugo Modules
+        uses: actions/cache@v4
+        with:
+          path: /tmp/hugo_cache
+          key: ${{ runner.os }}-hugomod-${{ hashFiles('docs/**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-hugomod-
+
+      - name: Install Dependencies
+        working-directory: docs/_preview
+        run: npm ci
+
+      - name: Build Validation docs
+        working-directory: docs/_preview
+        run: hugo -e development
+
+      # Cache Lychee results to avoid hitting rate limits.
+      # Key on the lychee.toml hash so that exclude-list edits (e.g. removing
+      # an exclude pattern) invalidate the cache deterministically; otherwise
+      # stale `200 OK` entries for the now-checked URLs would be trusted until
+      # `max_cache_age` expires.
+      - name: Cache Lychee results
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ runner.os }}-${{ hashFiles('lychee.toml') }}
+          restore-keys: |
+            cache-lychee-${{ runner.os }}-
+
+      # The cache key includes LYCHEE_VERSION_TAG so a version bump
+      # automatically pulls a fresh binary instead of reusing the old one.
+      # The restore-keys fallback lets a release-filename tweak (rare) reuse
+      # the existing cached binary for the same version-tag instead of paying
+      # for a fresh download.
+      - name: Cache Lychee executable
+        id: cache-lychee
+        uses: actions/cache@v4
+        with:
+          path: lychee
+          key: ${{ runner.os }}-${{ env.LYCHEE_VERSION_TAG }}-${{ env.LYCHEE_RELEASE }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.LYCHEE_VERSION_TAG }}-
+
+      # We use Lychee directly instead of a GitHub Action because it
+      # must have access to the local Hugo server, which is not visible
+      # from the Docker-based action.
+      #
+      # `if:` gating uses `hashFiles('lychee/lychee')` rather than
+      # `steps.cache-lychee.outputs.cache-hit != 'true'`. Per `actions/cache`
+      # docs, `cache-hit` is only `'true'` on an EXACT key match — a restore
+      # via `restore-keys` reports `cache-hit == 'false'`, even though the
+      # binary is present in the workspace. Re-downloading in that case
+      # would defeat the point of the fallback. `hashFiles` returns an empty
+      # string when the file is absent, so this guard runs the download iff
+      # neither the exact key nor any restore-key restored the binary.
+      - name: Download Lychee executable
+        uses: robinraju/release-downloader@v1.7
+        if: hashFiles('lychee/lychee') == ''
+        with:
+          repository: "lycheeverse/lychee"
+          tag: ${{ env.LYCHEE_VERSION_TAG }}
+          fileName: ${{ env.LYCHEE_RELEASE }}
+
+      # The v0.24.2 tarball contains a top-level directory
+      # (e.g. `lychee-x86_64-unknown-linux-gnu/lychee`), so `--strip-components=1`
+      # flattens it to `lychee/lychee` — matching what the companion
+      # `check-links` skill does locally and what the next step expects.
+      - name: Extract Lychee executable
+        if: hashFiles('lychee/lychee') == ''
+        run: |
+          mkdir -p lychee &&
+          tar -xzf ${{ env.LYCHEE_RELEASE }} --strip-components=1 -C lychee
+
+      # 1. In the generated HTML, some inner links will have absolute URLs and
+      #    the link checker will attempt to fetch them. That's why we need
+      #    a server. Sadly, link checkers have no settings to address this.
+      # 2. Output redirection is necessary for nohup in GitHub Actions.
+      # 3. Sleep + `curl` readiness check make sure the server is actually
+      #    serving HTTP before the next step runs Lychee. Without the curl
+      #    probe a silent startup failure (port already bound, missing
+      #    Hugo module, build error surfacing after `nohup` returns 0)
+      #    would manifest 60 s later as "every URL unreachable" Lychee
+      #    errors instead of pointing at the real cause. Mirrors the
+      #    `pgrep -F` guard in the companion `check-links` skill.
+      # 4. `--port 1313` is set explicitly (not relying on Hugo's default) so
+      #    the coupling with `--base-url http://localhost:1313/` in the next
+      #    Lychee step is visible — change one, change the other.
+      - name: Start Hugo server
+        working-directory: docs/_preview
+        run: |
+          nohup hugo server \
+          --environment development \
+          --port 1313 \
+          > nohup.out 2> nohup.err < /dev/null &
+          sleep 5
+          if ! curl -sf http://localhost:1313/ > /dev/null; then
+            echo "ERROR: Hugo server did not respond on port 1313." >&2
+            echo "--- stdout ---" >&2; cat nohup.out >&2 || true
+            echo "--- stderr ---" >&2; cat nohup.err >&2 || true
+            exit 1
+          fi
+
+      - name: Check links
+        run: |
+          ./lychee/lychee --config lychee.toml --timeout 60 \
+          --base-url http://localhost:1313/ \
+          'docs/_preview/public/**/*.html'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: docs/_preview/package-lock.json
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,6 +14,9 @@ env:
   HUGO_VERSION: 0.161.1
   LYCHEE_RELEASE: "lychee-x86_64-unknown-linux-gnu.tar.gz"
   LYCHEE_VERSION_TAG: "lychee-v0.24.2"
+  # SHA256 of the above tarball, pinned at download time. Update alongside
+  # LYCHEE_VERSION_TAG whenever the binary is upgraded.
+  LYCHEE_SHA256: "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
   # Force Hugo to write its module cache where the cache step actually
   # restores from. Hugo's default on Linux is `~/.cache/hugo_cache`
   # (or `$TMPDIR/hugo_cache_$USER`), neither of which matches the
@@ -114,6 +117,11 @@ jobs:
           repository: "lycheeverse/lychee"
           tag: ${{ env.LYCHEE_VERSION_TAG }}
           fileName: ${{ env.LYCHEE_RELEASE }}
+
+      - name: Verify Lychee checksum
+        if: hashFiles('lychee/lychee') == ''
+        run: |
+          echo "${{ env.LYCHEE_SHA256 }}  ${{ env.LYCHEE_RELEASE }}" | sha256sum --check --strict
 
       # The v0.24.2 tarball contains a top-level directory
       # (e.g. `lychee-x86_64-unknown-linux-gnu/lychee`), so `--strip-components=1`

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,10 @@ __pycache__/
 
 # Claude working files
 /.claude/worktrees/
+
+# Auto-downloaded Lychee binary used by the `link-check-docs` skill.
+/.agents/skills/link-check-docs/.cache/
+
+# Lychee link-checker cache (created by the `link-check-docs` skill and
+# the `proof-links` workflow when run locally).
+.lycheecache

--- a/.gitignore
+++ b/.gitignore
@@ -139,9 +139,9 @@ __pycache__/
 # Claude working files
 /.claude/worktrees/
 
-# Auto-downloaded Lychee binary used by the `link-check-docs` skill.
-/.agents/skills/link-check-docs/.cache/
+# Auto-downloaded Lychee binary used by the `check-links` skill.
+/.agents/skills/check-links/.cache/
 
-# Lychee link-checker cache (created by the `link-check-docs` skill and
-# the `proof-links` workflow when run locally).
+# Lychee link-checker cache (created by the `check-links` skill and
+# the `Check Links` workflow when run locally).
 .lycheecache

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ __pycache__/
 
 # Claude working files
 /.claude/worktrees/
+/.claude/settings.local.json
 
 # Auto-downloaded Lychee binary used by the `check-links` skill.
 /.agents/skills/check-links/.cache/

--- a/docs/content/docs/validation/developer/adding-a-built-in-option.md
+++ b/docs/content/docs/validation/developer/adding-a-built-in-option.md
@@ -200,6 +200,7 @@ internal class RequiredReaction : Reaction<FieldOptionDiscovered>() {
         val field = event.subject
         val file = event.file
         checkFieldType(field, file)
+        checkFieldIsNotEmpty(field, file)
 
         if (!event.option.boolValue) {
             return ignore()

--- a/docs/content/docs/validation/developer/architecture.md
+++ b/docs/content/docs/validation/developer/architecture.md
@@ -138,7 +138,7 @@ are:
 - [`validation_error.proto`](https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/proto/spine/validation/validation_error.proto)
   — defines `ValidationError` and `ConstraintViolation`, the structured shape of violation
   reports.
-- [`error_message.proto`](https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/proto/spine/validation/error_message.proto)
+- [`template_string.proto`](https://github.com/SpineEventEngine/base-libraries/blob/master/base/src/main/proto/spine/string/template_string.proto)
   — defines `TemplateString`, the placeholder format used by error messages.
 
 The runtime library does not parse `.proto` files, does not maintain a rule registry, and

--- a/docs/content/docs/validation/developer/build-and-release.md
+++ b/docs/content/docs/validation/developer/build-and-release.md
@@ -47,7 +47,7 @@ through Gradle's `extra` properties:
   end="val validationVersion">
 </embed-code>
 ```kotlin
-val validationVersion by extra("2.0.0-SNAPSHOT.440")
+val validationVersion by extra("2.0.0-SNAPSHOT.443")
 ```
 
 The root build script applies this file under `allprojects { … }` and assigns
@@ -72,6 +72,7 @@ spinePublishing {
     modules = setOf(
         "context",
         "java",
+        "java-settings",
         "java-bundle",
         "jvm-runtime",
     )

--- a/docs/content/docs/validation/developer/runtime-library.md
+++ b/docs/content/docs/validation/developer/runtime-library.md
@@ -185,7 +185,7 @@ first failure; it appends to a `List<ConstraintViolation>` and only at the end d
 whether to wrap the list in a `ValidationError`. This is what lets the runtime report
 every problem in one pass.
 
-`TemplateString` (in [`template_string.proto`][tempalte-string-proto]) is the format every
+`TemplateString` (in [`template_string.proto`][template-string-proto]) is the format every
 generator emits and every reader resolves. Substitution happens via
 `TemplateString.format()` (in Kotlin, [`TemplateStringExts.kt`][template-string-exts]) or
 the static `TemplateStrings.format(...)` (in Java). The placeholder names the runtime

--- a/docs/content/docs/validation/developer/runtime-library.md
+++ b/docs/content/docs/validation/developer/runtime-library.md
@@ -185,7 +185,7 @@ first failure; it appends to a `List<ConstraintViolation>` and only at the end d
 whether to wrap the list in a `ValidationError`. This is what lets the runtime report
 every problem in one pass.
 
-`TemplateString` (in [`error_message.proto`][error-message-proto]) is the format every
+`TemplateString` (in [`template_string.proto`][tempalte-string-proto]) is the format every
 generator emits and every reader resolves. Substitution happens via
 `TemplateString.format()` (in Kotlin, [`TemplateStringExts.kt`][template-string-exts]) or
 the static `TemplateStrings.format(...)` (in Java). The placeholder names the runtime
@@ -379,11 +379,11 @@ in `:context` and `:java`: anything that *can* be decided at build time *should*
 [validator-registry]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/kotlin/io/spine/validation/ValidatorRegistry.kt
 [detected-violation]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/kotlin/io/spine/validation/DetectedViolation.kt
 [validation-error-proto]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/proto/spine/validation/validation_error.proto
-[error-message-proto]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/proto/spine/validation/error_message.proto
 [violation-text]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/java/io/spine/validation/ViolationText.java
 [validate-class]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/java/io/spine/validation/Validate.java
 [exception-factory]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/java/io/spine/validation/ExceptionFactory.java
 [message-extensions]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/kotlin/io/spine/validation/MessageExtensions.kt
+[template-string-proto]: https://github.com/SpineEventEngine/base-libraries/blob/master/base/src/main/proto/spine/string/template_string.proto
 [template-string-exts]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/kotlin/io/spine/validation/TemplateStringExts.kt
 [standard-placeholder]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/kotlin/io/spine/validation/StandardPlaceholder.kt
 [timestamp-validator]: https://github.com/SpineEventEngine/validation/blob/master/jvm-runtime/src/main/kotlin/io/spine/validation/TimestampValidator.kt

--- a/docs/content/docs/validation/developer/validation-model.md
+++ b/docs/content/docs/validation/developer/validation-model.md
@@ -87,6 +87,7 @@ internal class RequiredReaction : Reaction<FieldOptionDiscovered>() {
         val field = event.subject
         val file = event.file
         checkFieldType(field, file)
+        checkFieldIsNotEmpty(field, file)
 
         if (!event.option.boolValue) {
             return ignore()

--- a/docs/content/docs/validation/user/01-getting-started/adding-to-build.md
+++ b/docs/content/docs/validation/user/01-getting-started/adding-to-build.md
@@ -90,7 +90,7 @@ Add the Validation plugin to the build.
 ```kotlin
 plugins {
     module
-    id("io.spine.validation") version "2.0.0-SNAPSHOT.440"
+    id("io.spine.validation") version "2.0.0-SNAPSHOT.443"
 }
 ```
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:validation-context:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-context:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -1090,14 +1090,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-context-tests:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-context-tests:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1791,7 +1791,7 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1812,7 +1812,7 @@ This report was generated on **Thu May 21 18:44:23 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:validation-gradle-plugin:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-gradle-plugin:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -2864,14 +2864,14 @@ This report was generated on **Thu May 21 18:44:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-java:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-java:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -3961,14 +3961,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-java-bundle:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-java-bundle:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -4015,14 +4015,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:08 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:14 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-java-settings:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-java-settings:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4798,14 +4798,14 @@ This report was generated on **Fri May 22 18:35:08 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-validation-jvm-runtime:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine:spine-validation-jvm-runtime:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5605,14 +5605,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-consumer:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-consumer:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -6294,14 +6294,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-consumer-dependency:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-consumer-dependency:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6759,14 +6759,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:08 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-extensions:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-extensions:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -7385,14 +7385,14 @@ This report was generated on **Fri May 22 18:35:08 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:08 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-runtime:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-runtime:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7953,14 +7953,14 @@ This report was generated on **Fri May 22 18:35:08 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-time:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-time:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8382,14 +8382,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:08 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-validating:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-validating:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8993,14 +8993,14 @@ This report was generated on **Fri May 22 18:35:08 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-validator:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-validator:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.21.3.
@@ -9738,14 +9738,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:09 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-validator-dependency:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-validator-dependency:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9978,14 +9978,14 @@ This report was generated on **Fri May 22 18:35:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:08 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-vanilla:2.0.0-SNAPSHOT.442`
+# Dependencies of `io.spine.tools:validation-vanilla:2.0.0-SNAPSHOT.443`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10328,6 +10328,6 @@ This report was generated on **Fri May 22 18:35:08 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 22 18:35:08 WEST 2026** using 
+This report was generated on **Fri May 22 22:19:15 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.442</version>
+<version>2.0.0-SNAPSHOT.443</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,76 @@
+# Lychee configuration for the `check-links` skill and the
+# `Check Links` GitHub workflow.
+#
+# Mirrors the configuration used by the sibling
+# `SpineEventEngine/SpineEventEngine.github.io` repository, with the same
+# exclude list of flaky external endpoints.
+
+# Exclude URLs and mail addresses from checking (supports regex).
+#
+# The entries are interpreted as Rust regexes, NOT shell globs:
+#   - `.` is escaped (`\.`) because an unescaped dot matches any character
+#     and would silently over-match (e.g. `fonts.googleapis.com` would
+#     also match `fontsXgoogleapisYcomZ`, masking real broken links).
+#   - `/.*` replaces the shell-style `/*` so a trailing path of any length
+#     matches (zero-or-more of any character, not zero-or-more slashes).
+# TOML literal strings (single-quoted) are used so backslashes stay
+# literal — basic strings (double quotes) would treat `\.` as an unknown
+# escape and either error out or strip the backslash.
+exclude = [
+    # Links that return errors during checks, but work for the user.
+    'fonts\.googleapis\.com/.*',
+    'fonts\.gstatic\.com/.*',
+    'chromium\.googlesource\.com/.*',
+    'chromereleases\.googleblog\.com/.*',
+    'clients4\.google\.com/.*',
+    'ssl\.gstatic\.com/.*',
+    'googletagmanager\.com/.*',
+    'x\.com/.*',
+
+    'stackoverflow\.com/questions/.*',
+    'openjdk\.org/.*',
+    'npmjs\.com/.*',
+    'medium\.com/.*',
+    'levelup\.gitconnected\.com/.*',
+]
+# Deliberately NOT excluded: `raw.githubusercontent.com/SpineEventEngine/*`.
+# Catching broken refs into our own raw GitHub content is part of the reason
+# this skill exists. If rate-limit flake appears, prefer narrowing the
+# pattern to the specific failing path rather than re-adding the broad rule.
+# Existing `max_retries`/`retry_wait_time` below should absorb transient 429s.
+
+# Exclude these filesystem paths from getting checked.
+exclude_path = []
+
+# Check links inside `<code>` and `<pre>` blocks as well
+# as Markdown code blocks.
+include_verbatim = false
+
+# Verbose program output
+verbose = "error"
+
+# Don't show the interactive progress bar while checking links. Both
+# consumers (CI and the `check-links` skill) run non-interactively, so
+# the progress bar adds noise to logs without value.
+no_progress = true
+
+# Comma-separated list of accepted status codes for valid links.
+# `429` (Too Many Requests) is accepted as a tradeoff against CI flake: some
+# providers rate-limit unauthenticated link probes from CI runners even when
+# the URL is healthy. Combined with `max_retries`/`retry_wait_time` below,
+# this avoids spurious failures on healthy-but-rate-limited URLs. The
+# downside: a URL that is genuinely broken AND returns `429` (rare) will
+# pass. Revisit this if false negatives accumulate.
+accept = ["200..=204", "429"]
+
+# Link caching to avoid checking the same links on multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "3d"
+
+# Maximum number of allowed retries before a link is declared dead.
+max_retries = 3
+
+# Minimum wait time in seconds between retries of failed requests.
+retry_wait_time = 2

--- a/lychee.toml
+++ b/lychee.toml
@@ -42,8 +42,8 @@ exclude = [
 # Exclude these filesystem paths from getting checked.
 exclude_path = []
 
-# Check links inside `<code>` and `<pre>` blocks as well
-# as Markdown code blocks.
+# Do NOT check links inside `<code>` and `<pre>` blocks or
+# Markdown code blocks (verbatim/code sections are excluded).
 include_verbatim = false
 
 # Verbose program output

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the Validation library to publish.
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.442")
+val validationVersion by extra("2.0.0-SNAPSHOT.443")


### PR DESCRIPTION
This PR introduces `check-links` skill and GitHub workflow employing Lychee tool which we already use in [spine.io repo](https://github.com/SpineEventEngine/SpineEventEngine.github.io) for catching broken links.

Broken links were also fixed. The skill will be added to `config` after we try it locally to this repo.