### PR TITLE
Credit Spine Compiler codegen execution to coverage

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -9,7 +9,7 @@ See [README.md](README.md) for the format and routing rules.
 
 ## Project (durable context & rationale)
 
-*(no entries yet)*
+- [codegen-coverage-blind-spot](project/codegen-coverage-blind-spot.md) — Why the `java`/`context` codegen modules report ~0% coverage — they run out-of-process in the forked Spine Compiler JVM, which JaCoCo/Kover do not instrument.
 
 ## Reference (external systems)
 

--- a/.agents/memory/project/codegen-coverage-blind-spot.md
+++ b/.agents/memory/project/codegen-coverage-blind-spot.md
@@ -1,0 +1,32 @@
+---
+name: codegen-coverage-blind-spot
+description: Why the `java`/`context` codegen modules report ~0% coverage — they run out-of-process in the forked Spine Compiler JVM, which JaCoCo/Kover do not instrument.
+metadata:
+  type: project
+  since: 2026-07-06
+---
+
+The `java` and `context` modules are Spine Compiler plugins/renderers (`JavaValidationPlugin`,
+the `*Generator` classes, the `expression/*` builders, the ProtoData plugin). They execute in the
+**forked `launch*SpineCompiler` (`JavaExec`) process** during the build, not in the `test` JVM.
+Kover/JaCoCo instrument only the test JVM, so this code reports **~0% line coverage** even though
+the `tests/*` and `context-tests` `.proto` fixtures exercise it on every build. The lone generator
+with real coverage — `UnsignedIntegerWarnings` (~82%) — has it because one spec instantiates it
+**in-process**. This is the main reason the repo total sits around ~12%.
+
+**Why:** So a future session seeing an alarmingly low total, or a codegen module at 0%, does not
+misread it as neglected/untested code or a quality regression and waste time re-deriving the cause.
+It is a measurement blind spot inherent to out-of-process code generation, not missing tests.
+
+**How to apply:** When coverage looks structurally low here, do **not** reach for sibling
+attribution (`SiblingCoverage.creditTestCoverageFrom`) or expect root Kover aggregation to fix it —
+those re-attribute execution data that already exists in-process, and for compiler-executed code no
+such data exists anywhere. Closing the gap requires **instrumenting the forked compiler JVM**:
+attach the standalone JaCoCo agent to the `launch*SpineCompiler` tasks and merge the resulting
+`.exec` via `KoverConfig`'s `additionalBinaryReports` — the same pattern
+`io.spine.gradle.testing.enableTestKitCoverage()` already uses for Gradle TestKit workers. The
+JVM-args/agent hook is best owned by the `SpineEventEngine/compiler` repo (the launch tasks are
+`JavaExec`, so `jvmArgs` is the natural injection point; the `compiler-fat-cli` does **not**
+relocate plugin classes, so JaCoCo class IDs match and `additionalBinaryReports` credits them
+correctly). Complement with in-process unit tests for logic-heavy
+generators, and report codegen vs. runtime under separate Codecov flags/components.

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -40,5 +40,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import io.spine.gradle.repo.standardToSpineSdk
 import io.spine.gradle.report.coverage.KoverConfig
 import io.spine.gradle.report.license.LicenseReporter
 import io.spine.gradle.report.pom.PomGenerator
+import io.spine.gradle.testing.enableSpineCompilerCoverage
 
 buildscript {
     standardSpineSdkRepositories()
@@ -140,5 +141,14 @@ allprojects {
 }
 
 KoverConfig.applyTo(rootProject)
+
+// Attach the JaCoCo agent to the forked Spine Compiler JVMs so that the
+// out-of-process execution of code-generation plugins (the `java` and `context`
+// modules' renderers and generators) is credited to the root coverage report.
+// A no-op for modules that run no `launch*SpineCompiler` task.
+subprojects {
+    enableSpineCompilerCoverage()
+}
+
 LicenseReporter.mergeAllReports(project)
 PomGenerator.applyTo(project)

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Jacoco.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Jacoco.kt
@@ -34,4 +34,12 @@ package io.spine.dependency.test
 @Suppress("ConstPropertyName")
 object Jacoco {
     const val version = "0.8.15"
+
+    /**
+     * The Maven coordinates of the standalone JaCoCo agent JAR (the `runtime`
+     * classifier), attached via `-javaagent:` to forked JVMs — Gradle TestKit
+     * workers and the Spine Compiler process — so their execution is credited
+     * to coverage.
+     */
+    const val agent = "org.jacoco:org.jacoco.agent:$version:runtime"
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
@@ -28,6 +28,7 @@ package io.spine.gradle.report.coverage
 
 import io.spine.dependency.test.Jacoco
 import io.spine.dependency.test.Kover
+import io.spine.gradle.testing.COMPILER_COVERAGE_DIR
 import io.spine.gradle.testing.TESTKIT_COVERAGE_DIR
 import java.io.File
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
@@ -104,6 +105,13 @@ private const val KOTLIN_FILE_CLASS_SUFFIX: String = "Kt"
  *    the probe level against each module's actual bytecode: a line hit both
  *    in-process and out-of-process is counted once. Summing pre-aggregated XML
  *    reports instead would double-count such lines.
+ *  - Feeds the JaCoCo execution data produced by the forked Spine Compiler JVMs
+ *    (see [io.spine.gradle.testing.enableSpineCompilerCoverage]) into the **root**
+ *    `total` report as `additionalBinaryReports`. This credits the code-generation
+ *    plugins in the `java` and `context` modules — renderers and generators that
+ *    run out-of-process in the compiler fork and are otherwise reported at ~0%.
+ *    Fed only at the root: Codecov ingests the root report, whose aggregation owns
+ *    those classes, so a per-module feed would be redundant.
  *
  * This is the Kover-based successor to the deprecated JaCoCo-based
  * coverage aggregation pipeline. The behaviour mirrors what
@@ -198,6 +206,7 @@ class KoverConfig private constructor(
                         onCheck.set(true)
                     }
                     additionalBinaryReports.addAll(rootTestKitExecFilesProvider())
+                    additionalBinaryReports.addAll(rootCompilerExecFilesProvider())
                 }
                 filters {
                     excludes {
@@ -240,6 +249,27 @@ class KoverConfig private constructor(
             rootProject.subprojects.asSequence()
                 .filter { it.pluginManager.hasPlugin(Kover.id) }
                 .flatMap { testKitExecFiles(it).asSequence() }
+                .toList()
+        }
+
+    /**
+     * Lazy `Provider` of the JaCoCo execution-data files produced by the forked
+     * Spine Compiler JVMs across every subproject.
+     *
+     * These files credit the out-of-process execution of compiler plugins — the
+     * renderers and generators in the `java` and `context` modules — to the root
+     * coverage rollup. Unlike the TestKit files, they are collected from **all**
+     * subprojects regardless of whether the producing module applies Kover: the
+     * exec is produced by a test module's `launch*SpineCompiler` task, but the
+     * classes it credits belong to the aggregated production modules. Resolved at
+     * task-graph time, after the launch tasks have written them.
+     *
+     * @see io.spine.gradle.testing.enableSpineCompilerCoverage
+     */
+    private fun rootCompilerExecFilesProvider(): Provider<Iterable<File>> =
+        rootProject.provider {
+            rootProject.subprojects.asSequence()
+                .flatMap { compilerExecFiles(it).asSequence() }
                 .toList()
         }
 
@@ -293,6 +323,23 @@ class KoverConfig private constructor(
  */
 private fun testKitExecFiles(project: Project): List<File> {
     val dir = project.layout.buildDirectory.dir(TESTKIT_COVERAGE_DIR).get().asFile
+    if (!dir.isDirectory) {
+        return emptyList()
+    }
+    return dir.listFiles { file -> file.isFile && file.extension == "exec" }
+        ?.sorted()
+        ?: emptyList()
+}
+
+/**
+ * Returns the JaCoCo execution-data (`.exec`) files written by the forked Spine
+ * Compiler JVMs of the [project], or an empty list if the module produced none.
+ *
+ * The files reside under `build/`[COMPILER_COVERAGE_DIR] and are created when a
+ * module opts in via [io.spine.gradle.testing.enableSpineCompilerCoverage].
+ */
+private fun compilerExecFiles(project: Project): List<File> {
+    val dir = project.layout.buildDirectory.dir(COMPILER_COVERAGE_DIR).get().asFile
     if (!dir.isDirectory) {
         return emptyList()
     }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
@@ -27,7 +27,6 @@
 package io.spine.gradle.testing
 
 import io.spine.dependency.test.Jacoco
-import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.JavaExec
@@ -35,7 +34,8 @@ import org.gradle.kotlin.dsl.withType
 
 /**
  * Configures the `launch*SpineCompiler` tasks of this project so that the JaCoCo
- * agent is attached to the forked JVM that runs the Spine Compiler.
+ * agent is attached to the forked JVM that runs the Spine Compiler, and the
+ * resulting execution data is captured as a task output.
  *
  * The Spine Compiler executes plugin code — renderers, option generators, and
  * ProtoData plugins such as `JavaValidationPlugin` — in a **separate JVM** spawned
@@ -46,34 +46,35 @@ import org.gradle.kotlin.dsl.withType
  *
  * For every such launch task, this method:
  *
- *  1. Resolves the standalone JaCoCo agent JAR pinned to [Jacoco.version] through a
- *     dedicated [AGENT_CONFIGURATION] configuration.
+ *  1. Resolves the standalone JaCoCo agent JAR ([Jacoco.agent]) through a dedicated
+ *     [AGENT_CONFIGURATION] configuration.
  *  2. Attaches
- *     `-javaagent:<agent>=destfile=build/`[COMPILER_COVERAGE_DIR]`/<task>.exec,append=true`
- *     to the forked JVM. A per-task destination file keeps the launch variants
- *     (main, test, test-fixtures) from clobbering one another.
- *  3. Wipes the exec directory at most once per build invocation, from the `doFirst`
- *     of the first launch task that actually executes, so stale coverage from a
- *     previous run does not accumulate. A `doFirst` action (rather than a `dependsOn`
- *     clean task) runs only when the task truly executes: an `UP-TO-DATE` launch keeps
- *     the previous `.exec`, which the report then still credits.
- *  4. Marks the launch tasks non-cacheable. The agent's `.exec` is flushed
- *     out-of-process on JVM shutdown, *after* the task action completes, so it cannot
- *     be a declared task output. Were the task left cacheable, a cache hit would
- *     restore the generated sources but no `.exec`, dropping the coverage.
+ *     `-javaagent:<agent>=destfile=build/`[COMPILER_COVERAGE_DIR]`/<task>.exec,append=false`
+ *     to the forked JVM. Each launch variant (main, test, test-fixtures) writes its
+ *     own per-task file, and `append=false` makes every run overwrite it, so a
+ *     re-run never accumulates a previous run's probes.
+ *  3. Declares that `.exec` file as a **task output**, which keeps the launch tasks
+ *     cacheable. A `JavaExec` task blocks until the forked JVM exits, and the agent
+ *     flushes the exec on that exit — so the file is already on disk when the task
+ *     action returns and *can* be a declared output. Declaring it lets Gradle's
+ *     build cache store and restore it, so the coverage survives both an
+ *     `UP-TO-DATE` skip (the file stays on disk from the previous run) and a
+ *     `FROM-CACHE` hit (the file is restored from the cache). This is the key
+ *     difference from [enableTestKitCoverage], whose TestKit worker daemon flushes
+ *     its exec only *after* the `Test` task completes and therefore cannot declare
+ *     it — which is why that helper must instead disable caching.
  *
- * The agent is attached and the destination file computed from a `doFirst` action —
- * the same approach [enableTestKitCoverage] uses for TestKit workers — rather than a
- * `jvmArgumentProviders` entry, so the two coverage helpers stay structurally
- * identical and neither contributes untracked task inputs.
+ * The agent is attached from a `doFirst` action rather than a `jvmArgumentProviders`
+ * entry so that its absolute path stays out of the task's input fingerprint: the
+ * exec content depends on the compiler's own inputs (which drive what code runs), so
+ * keying up-to-dateness and the cache on those inputs is exactly right.
  *
  * The produced `.exec` files are merged into the **root** Kover report by
  * [io.spine.gradle.report.coverage.KoverConfig]. Only classes the root aggregation
  * owns (the `java` and `context` modules' renderers/generators) are credited from
- * them; a Kover report is scoped to its own classes, and the compiler loads those
- * classes as their original, un-relocated artifacts, so JaCoCo's class IDs match.
- * The agent emits binary execution data because Kover merges binary data at the
- * probe level — see `KoverConfig` for why binary, not XML.
+ * them; the compiler loads those classes as their original, un-relocated artifacts,
+ * so JaCoCo's class IDs match. The agent emits binary execution data because Kover
+ * merges binary data at the probe level — see `KoverConfig` for why binary, not XML.
  *
  * The method is idempotent and may be called on every subproject; it is a no-op for
  * modules that declare no `launch*SpineCompiler` task.
@@ -83,34 +84,25 @@ fun Project.enableSpineCompilerCoverage() {
         isCanBeConsumed = false
         isCanBeResolved = true
     }
-    dependencies.add(agent.name, "org.jacoco:org.jacoco.agent:${Jacoco.version}:runtime")
+    dependencies.add(agent.name, Jacoco.agent)
 
     val agentPath = agent.elements.map { it.single().asFile.absolutePath }
     val execDir = layout.buildDirectory.dir(COMPILER_COVERAGE_DIR)
 
-    // Wiped at most once per build invocation, by the first launch task that actually
-    // executes — see the KDoc above for why this is a guarded `doFirst` wipe rather
-    // than a `dependsOn` clean task.
-    val cleaned = AtomicBoolean(false)
-
     val launchTasks = tasks.withType<JavaExec>().matching { it.isSpineCompilerLaunchTask() }
 
     launchTasks.configureEach {
-        inputs.files(agent).withPropertyName(AGENT_CONFIGURATION)
-        outputs.cacheIf(
-            "The Spine Compiler coverage exec is produced out-of-process and cannot " +
-                    "be a declared task output; a cache hit would drop it."
-        ) { false }
+        val taskName = name
+        val execFile = execDir.map { it.file("$taskName.exec") }
+        // Captured as a task output so the build cache stores and restores it —
+        // see the KDoc for why a synchronous `JavaExec` can declare its agent exec
+        // while a TestKit worker cannot.
+        outputs.file(execFile)
         doFirst {
-            val dir = execDir.get().asFile
-            if (cleaned.compareAndSet(false, true)) {
-                dir.deleteRecursively()
-            }
-            dir.mkdirs()
-            val execFile = dir.resolve("$name.exec")
+            val file = execFile.get().asFile
+            file.parentFile.mkdirs()
             jvmArgs(
-                "-javaagent:${agentPath.get()}=destfile=${execFile.absolutePath}," +
-                        "append=true,output=file"
+                "-javaagent:${agentPath.get()}=destfile=${file.absolutePath},append=false"
             )
         }
     }
@@ -157,11 +149,10 @@ internal const val COMPILER_COVERAGE_DIR: String = "jacoco-compiler"
 
 /**
  * The name of the dedicated, resolvable configuration that holds the standalone
- * JaCoCo agent JAR (`org.jacoco:org.jacoco.agent:<version>:runtime`) attached to
- * the forked Spine Compiler JVMs.
+ * JaCoCo agent JAR ([Jacoco.agent]) attached to the forked Spine Compiler JVMs.
  *
  * The configuration is hidden and non-consumable; it exists only to resolve the
- * agent JAR and to register it as an input of the launch tasks.
+ * agent JAR.
  */
 private const val AGENT_CONFIGURATION: String = "spineCompilerJacocoAgent"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.testing
+
+import io.spine.dependency.test.Jacoco
+import java.util.concurrent.atomic.AtomicBoolean
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.JavaExec
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * Configures the `launch*SpineCompiler` tasks of this project so that the JaCoCo
+ * agent is attached to the forked JVM that runs the Spine Compiler.
+ *
+ * The Spine Compiler executes plugin code — renderers, option generators, and
+ * ProtoData plugins such as `JavaValidationPlugin` — in a **separate JVM** spawned
+ * by the `launch[<SourceSet>]SpineCompiler`
+ * [JavaExec][org.gradle.api.tasks.JavaExec] tasks. Kover (and JaCoCo) instrument
+ * only the `test` JVM, so this out-of-process execution is otherwise not credited
+ * to coverage, even though the module's `.proto` fixtures exercise it on every build.
+ *
+ * For every such launch task, this method:
+ *
+ *  1. Resolves the standalone JaCoCo agent JAR pinned to [Jacoco.version] through a
+ *     dedicated [AGENT_CONFIGURATION] configuration.
+ *  2. Attaches
+ *     `-javaagent:<agent>=destfile=build/`[COMPILER_COVERAGE_DIR]`/<task>.exec,append=true`
+ *     to the forked JVM. A per-task destination file keeps the launch variants
+ *     (main, test, test-fixtures) from clobbering one another.
+ *  3. Wipes the exec directory at most once per build invocation, from the `doFirst`
+ *     of the first launch task that actually executes, so stale coverage from a
+ *     previous run does not accumulate. A `doFirst` action (rather than a `dependsOn`
+ *     clean task) runs only when the task truly executes: an `UP-TO-DATE` launch keeps
+ *     the previous `.exec`, which the report then still credits.
+ *  4. Marks the launch tasks non-cacheable. The agent's `.exec` is flushed
+ *     out-of-process on JVM shutdown, *after* the task action completes, so it cannot
+ *     be a declared task output. Were the task left cacheable, a cache hit would
+ *     restore the generated sources but no `.exec`, dropping the coverage.
+ *
+ * The agent is attached and the destination file computed from a `doFirst` action —
+ * the same approach [enableTestKitCoverage] uses for TestKit workers — rather than a
+ * `jvmArgumentProviders` entry, so the two coverage helpers stay structurally
+ * identical and neither contributes untracked task inputs.
+ *
+ * The produced `.exec` files are merged into the **root** Kover report by
+ * [io.spine.gradle.report.coverage.KoverConfig]. Only classes the root aggregation
+ * owns (the `java` and `context` modules' renderers/generators) are credited from
+ * them; a Kover report is scoped to its own classes, and the compiler loads those
+ * classes as their original, un-relocated artifacts, so JaCoCo's class IDs match.
+ * The agent emits binary execution data because Kover merges binary data at the
+ * probe level — see `KoverConfig` for why binary, not XML.
+ *
+ * The method is idempotent and may be called on every subproject; it is a no-op for
+ * modules that declare no `launch*SpineCompiler` task.
+ */
+fun Project.enableSpineCompilerCoverage() {
+    val agent = configurations.maybeCreate(AGENT_CONFIGURATION).apply {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+    dependencies.add(agent.name, "org.jacoco:org.jacoco.agent:${Jacoco.version}:runtime")
+
+    val agentPath = agent.elements.map { it.single().asFile.absolutePath }
+    val execDir = layout.buildDirectory.dir(COMPILER_COVERAGE_DIR)
+
+    // Wiped at most once per build invocation, by the first launch task that actually
+    // executes — see the KDoc above for why this is a guarded `doFirst` wipe rather
+    // than a `dependsOn` clean task.
+    val cleaned = AtomicBoolean(false)
+
+    val launchTasks = tasks.withType<JavaExec>().matching { it.isSpineCompilerLaunchTask() }
+
+    launchTasks.configureEach {
+        inputs.files(agent).withPropertyName(AGENT_CONFIGURATION)
+        outputs.cacheIf(
+            "The Spine Compiler coverage exec is produced out-of-process and cannot " +
+                    "be a declared task output; a cache hit would drop it."
+        ) { false }
+        doFirst {
+            val dir = execDir.get().asFile
+            if (cleaned.compareAndSet(false, true)) {
+                dir.deleteRecursively()
+            }
+            dir.mkdirs()
+            val execFile = dir.resolve("$name.exec")
+            jvmArgs(
+                "-javaagent:${agentPath.get()}=destfile=${execFile.absolutePath}," +
+                        "append=true,output=file"
+            )
+        }
+    }
+
+    // The root Kover report/verification tasks read these exec files as
+    // `additionalBinaryReports`, but do not otherwise depend on the (non-Kover)
+    // test modules that produce them. Order them explicitly after the launch
+    // tasks — otherwise the report may run before the exec is written.
+    rootProject.tasks
+        .matching { it.isCoverageReportTask() }
+        .configureEach { dependsOn(launchTasks) }
+}
+
+/**
+ * Tells whether this is one of the `launch[<SourceSet>]SpineCompiler` tasks that
+ * fork the Spine Compiler — matched by name to avoid a compile-time dependency on
+ * the compiler Gradle plugin's task types.
+ */
+private fun Task.isSpineCompilerLaunchTask(): Boolean =
+    name.startsWith(LAUNCH_TASK_PREFIX) && name.endsWith(LAUNCH_TASK_SUFFIX)
+
+/**
+ * Tells whether this is a Kover report or verification task — one that reads the
+ * binary exec files and must therefore run only after the launch tasks that write
+ * them. Matches `koverXmlReport`, `koverHtmlReport`, `koverVerify`, and their
+ * `Cached*` companions.
+ */
+private fun Task.isCoverageReportTask(): Boolean =
+    name.startsWith(KOVER_TASK_PREFIX) &&
+            (name.endsWith(REPORT_TASK_SUFFIX) || name.endsWith(VERIFY_TASK_SUFFIX))
+
+/**
+ * The name of the directory under a module's `build` directory where the coverage
+ * of forked Spine Compiler JVMs is collected.
+ *
+ * The directory holds JaCoCo execution-data (`.exec`) files — one per launch task —
+ * written by the JaCoCo agent attached to the compiler fork. `KoverConfig` picks
+ * these files up and feeds them into the root Kover report as additional binary
+ * reports.
+ *
+ * @see io.spine.gradle.report.coverage.KoverConfig
+ */
+internal const val COMPILER_COVERAGE_DIR: String = "jacoco-compiler"
+
+/**
+ * The name of the dedicated, resolvable configuration that holds the standalone
+ * JaCoCo agent JAR (`org.jacoco:org.jacoco.agent:<version>:runtime`) attached to
+ * the forked Spine Compiler JVMs.
+ *
+ * The configuration is hidden and non-consumable; it exists only to resolve the
+ * agent JAR and to register it as an input of the launch tasks.
+ */
+private const val AGENT_CONFIGURATION: String = "spineCompilerJacocoAgent"
+
+private const val LAUNCH_TASK_PREFIX: String = "launch"
+private const val LAUNCH_TASK_SUFFIX: String = "SpineCompiler"
+
+private const val KOVER_TASK_PREFIX: String = "kover"
+private const val REPORT_TASK_SUFFIX: String = "Report"
+private const val VERIFY_TASK_SUFFIX: String = "Verify"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
@@ -84,7 +84,7 @@ fun Project.enableTestKitCoverage() {
         isCanBeConsumed = false
         isCanBeResolved = true
     }
-    dependencies.add(agent.name, "org.jacoco:org.jacoco.agent:${Jacoco.version}:runtime")
+    dependencies.add(agent.name, Jacoco.agent)
 
     val agentPath = agent.elements.map { it.single().asFile.absolutePath }
     val execDir = layout.buildDirectory.dir(TESTKIT_COVERAGE_DIR)

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:validation-context:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-context:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1106,14 +1106,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-context-tests:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-context-tests:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1607,6 +1607,9 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1803,28 +1806,31 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-docs:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-docs:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 ## Compile, tests, and tooling
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:07 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:58 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-gradle-plugin:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-gradle-plugin:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2864,14 +2870,14 @@ This report was generated on **Mon Jul 06 16:20:07 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-java:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-java:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3977,14 +3983,14 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-java-bundle:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-java-bundle:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -4008,6 +4014,9 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## Compile, tests, and tooling
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4031,14 +4040,14 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:07 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:58 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-java-settings:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-java-settings:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4838,14 +4847,14 @@ This report was generated on **Mon Jul 06 16:20:07 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-validation-jvm-runtime:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine:spine-validation-jvm-runtime:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5665,14 +5674,14 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-consumer:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-consumer:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -6162,6 +6171,9 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6350,14 +6362,14 @@ This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-consumer-dependency:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-consumer-dependency:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6656,6 +6668,9 @@ This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using
      * **Project URL:** [http://functionaljava.org/](http://functionaljava.org/)
      * **License:** [The BSD3 License](https://github.com/functionaljava/functionaljava/blob/master/etc/LICENCE)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6811,14 +6826,14 @@ This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:11 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-extensions:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-extensions:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -7274,6 +7289,9 @@ This report was generated on **Mon Jul 06 16:20:11 WEST 2026** using
      * **Project URL:** [http://functionaljava.org/](http://functionaljava.org/)
      * **License:** [The BSD3 License](https://github.com/functionaljava/functionaljava/blob/master/etc/LICENCE)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7429,14 +7447,14 @@ This report was generated on **Mon Jul 06 16:20:11 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:13 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-runtime:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-runtime:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7805,6 +7823,9 @@ This report was generated on **Mon Jul 06 16:20:13 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7993,14 +8014,14 @@ This report was generated on **Mon Jul 06 16:20:13 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:19 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:59:00 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-time:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-time:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8238,6 +8259,9 @@ This report was generated on **Mon Jul 06 16:20:19 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8422,14 +8446,14 @@ This report was generated on **Mon Jul 06 16:20:19 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-validating:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-validating:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8829,6 +8853,9 @@ This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -9033,14 +9060,14 @@ This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:24 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-validator:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-validator:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -9566,6 +9593,9 @@ This report was generated on **Mon Jul 06 16:20:24 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -9770,14 +9800,14 @@ This report was generated on **Mon Jul 06 16:20:24 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:14 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-validator-dependency:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-validator-dependency:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9899,6 +9929,9 @@ This report was generated on **Mon Jul 06 16:20:14 WEST 2026** using
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](https://opensource.org/licenses/MIT)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -10010,14 +10043,14 @@ This report was generated on **Mon Jul 06 16:20:14 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:09 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:validation-vanilla:2.0.0-SNAPSHOT.447`
+# Dependencies of `io.spine.tools:validation-vanilla:2.0.0-SNAPSHOT.448`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10252,6 +10285,9 @@ This report was generated on **Mon Jul 06 16:20:09 WEST 2026** using
 1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
      * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -10360,6 +10396,6 @@ This report was generated on **Mon Jul 06 16:20:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
+This report was generated on **Mon Jul 06 18:58:59 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1106,7 +1106,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:43 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1803,7 +1803,7 @@ This report was generated on **Sun Jul 05 23:28:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:47 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1817,7 +1817,7 @@ This report was generated on **Sun Jul 05 23:28:47 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:33 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2864,7 +2864,7 @@ This report was generated on **Sun Jul 05 23:28:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:42 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3977,7 +3977,7 @@ This report was generated on **Sun Jul 05 23:28:42 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:43 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4031,7 +4031,7 @@ This report was generated on **Sun Jul 05 23:28:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:35 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4838,7 +4838,7 @@ This report was generated on **Sun Jul 05 23:28:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:42 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5665,7 +5665,7 @@ This report was generated on **Sun Jul 05 23:28:42 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:42 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6350,7 +6350,7 @@ This report was generated on **Sun Jul 05 23:28:42 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:40 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6811,7 +6811,7 @@ This report was generated on **Sun Jul 05 23:28:40 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:41 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:11 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7429,7 +7429,7 @@ This report was generated on **Sun Jul 05 23:28:41 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:47 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7993,7 +7993,7 @@ This report was generated on **Sun Jul 05 23:28:47 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:41 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:19 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8422,7 +8422,7 @@ This report was generated on **Sun Jul 05 23:28:41 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:41 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9033,7 +9033,7 @@ This report was generated on **Sun Jul 05 23:28:41 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:52 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:24 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9770,7 +9770,7 @@ This report was generated on **Sun Jul 05 23:28:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:47 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:14 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10010,7 +10010,7 @@ This report was generated on **Sun Jul 05 23:28:47 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:38 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:09 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10360,6 +10360,6 @@ This report was generated on **Sun Jul 05 23:28:38 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jul 05 23:28:40 WEST 2026** using 
+This report was generated on **Mon Jul 06 16:20:10 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>validation</artifactId>
-<version>2.0.0-SNAPSHOT.447</version>
+<version>2.0.0-SNAPSHOT.448</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -351,12 +351,22 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>abi-tools</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-compat</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-impl</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -351,22 +351,12 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>abi-tools</artifactId>
-    <version>2.3.21</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-compat</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-impl</artifactId>
-    <version>2.3.21</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the Validation library to publish.
  */
-val validationVersion by extra("2.0.0-SNAPSHOT.447")
+val validationVersion by extra("2.0.0-SNAPSHOT.448")


### PR DESCRIPTION
## What & why

The `java` and `context` modules — the Spine Compiler plugins, renderers, and option
generators — execute in the **forked `launch*SpineCompiler` JVM** during the build, which
Kover/JaCoCo do not instrument. They reported **~0% line coverage** even though the `tests/*`
`.proto` fixtures exercise them on every build, holding the repo total near **12%** (matching
Codecov).

This attaches the standalone JaCoCo agent to the forked compiler JVM, harvests its `.exec`, and
merges it into the **root** Kover report (the one Codecov ingests) — mirroring the existing
`enableTestKitCoverage()` pipeline for Gradle TestKit workers.

## How

- **`enableSpineCompilerCoverage()`** (new `buildSrc/.../testing/SpineCompilerCoverage.kt`)
  attaches `-javaagent:<Jacoco.agent>=destfile=…/<task>.exec,append=false` to every
  `launch*SpineCompiler` `JavaExec` task, with a per-task destfile.
- The `.exec` is **declared as a task output**, so the launch tasks stay **cacheable**: a
  `JavaExec` blocks until the fork exits and the agent flushes the exec on exit, so the file is on
  disk when the task action returns and *can* be a declared output — unlike a lingering TestKit
  worker daemon (which is why `enableTestKitCoverage()` still disables caching). Coverage therefore
  survives both an `UP-TO-DATE` skip and a `FROM-CACHE` hit.
- **`KoverConfig`** feeds the exec into the root report's `additionalBinaryReports`, and orders
  `kover*Report`/`kover*Verify` after the launch tasks — the root report does not otherwise depend
  on the non-Kover `tests/*` modules that produce the exec.
- The JaCoCo agent coordinate is centralized as `Jacoco.agent` (shared with the TestKit helper).
- Applied via `subprojects { enableSpineCompilerCoverage() }`; a no-op where no launch task exists.

Class IDs match by construction: the compiler CLI shadow jar does no `relocate()` and loads
consumer plugin classes as their original artifacts (verified in the `compiler` repo, Phases 0–1).

## Result (verified locally)

`./gradlew clean build koverXmlReport` → root report **12% → 86.3%** line coverage
(`covered 1894 / 2195`), reconciling exactly with Codecov's 12.35% baseline. Ten `.exec` files are
produced across all three launch-task variants. Generators flip 0% → covered:
`MinGenerator`/`MaxGenerator`/`RangeGenerator` 100%, `JavaValidationRenderer` 97.8%,
`BoundedFieldGenerator` 88%. `ValidatorGenerator` stays **0%** — a genuine gap (no fixture declares
a custom `@Validator`), confirming the measure is discriminating rather than blanket-crediting.

**Caching verified:** a no-change re-run is `UP-TO-DATE`; deleting the exec makes the task
`FROM-CACHE` and restores the exec; the full build reports `1 from cache`.

## Caveats / follow-ups

- This is **execution coverage** of codegen, not assertion-backed unit coverage — genuine (the code
  runs against the fixtures) but more generous. A follow-up should report it under a **separate
  Codecov flag** (`codegen` vs `runtime`) and upstream the two `buildSrc` helpers to `config`.
- The version bump's dependency/license-report refresh was not run separately; a report-update
  commit from the working tree is included, but if CI's report check flags a `.448` mismatch, run
  the report task.

## Pre-PR

PASS — `./gradlew build dokkaGenerate` green; `spine-code-review` + `kotlin-engineer` APPROVE.

## Note on commits

Opened as-is per request. Beyond the coverage feature, the version bump, and a review-feedback
commit (cacheable exec + `Jacoco.agent`), this PR also carries three commits from local-`master`
drift: a team-memory note (`.agents/memory/*`), a dependency-report update (`docs/dependencies/*`),
and an IDE-config change (`.idea/misc.xml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
